### PR TITLE
Prevent errors when last_element is a number.

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -54,7 +54,7 @@ Client.prototype.request = function (method, uri) {
     if (typeof last_element === 'object') {// we have recieved an object ex. {"sort_by":"id","sort_order":"desc"}
       params = '?' + qs.stringify(last_element);
     } else { // we have recieved a query string ex. '?sort_by=id&sort_order=desc'
-      if (last_element.indexOf('?') === 0) {
+      if (last_element.toString().indexOf('?') === 0) {
         params = last_element;
       } else {
         uri.push(last_element);


### PR DESCRIPTION
In cases where last_element is a number (users.update or tickets.update) a fatal error will be thrown when trying to call indexOf().  This ensures that the URL last_element is converted to a string before calling indexOf() which will ensure this doesn't fail.
