### PR TITLE
Zendesk is sending back 422 errors when organization name is being re-used

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -94,7 +94,7 @@ Client.prototype.request = function (method, uri) {
           method: method || 'GET',
           uri: url,
           headers: headerObj
-        };   
+        };
     }
   }
 
@@ -118,7 +118,7 @@ Client.prototype.request = function (method, uri) {
     }
 
     var statusCode, error;
-    
+
     if(!result){ //should this really be an error?
       error = new Error('Zendesk returned an empty result');
       error.statusCode = 204;
@@ -160,7 +160,7 @@ Client.prototype.request = function (method, uri) {
         if (!body && self.jsonAPIName3 !== null) {
             body = res[(self.jsonAPIName3.toString())];
         }
-        
+
         if (!body) {
             body = res;
         }
@@ -168,7 +168,7 @@ Client.prototype.request = function (method, uri) {
     else {
         body = "";
     }
-    
+
     callback(null, statusCode, body, response, res);
   });
 };
@@ -285,8 +285,8 @@ var failCodes = {
   404: 'Item not found',
   405: 'Method not Allowed',
   409: 'Conflict',
+  422: 'Unprocessable Entity',   // zendesk sends this one back when you re-use an organization name
   429: 'Too Many Requests',
   500: 'Internal Server Error',
   503: 'Service Unavailable'
 };
-


### PR DESCRIPTION
Zendesk is sending back 422 errors when organization name is being re-used

it would help if the library recognised that 422 was a failCode - that way the proper error call back function is called.
