### PR TITLE
Adding 2 more organization API end points

### DIFF
--- a/lib/client/organizations.js
+++ b/lib/client/organizations.js
@@ -44,3 +44,13 @@ Organizations.prototype.update = function (organizationID, organization, cb) {
 Organizations.prototype.delete = function (organizationID, cb) {
   this.request('DELETE', ['organizations', organizationID],  cb);
 };
+
+// ====================================== Search Organizations
+Organizations.prototype.search = function (params, cb) {
+  this.requestAll('GET', ['organizations', 'search', params], cb);
+};
+
+// ====================================== Autocomplete Organizations
+Organizations.prototype.autocomplete = function (params, cb) {
+  this.requestAll('GET', ['organizations', 'autocomplete', params], cb);
+};


### PR DESCRIPTION
I needed the search end point (for searching by external_id) and also found the autocomplete endpoint better then the generic search with type:organization for anything that had yet to be indexed.
