### PR TITLE
Added support for `users.merge` API call

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -399,6 +399,7 @@ suspend(id, cb)
 delete(id, cb)
 search(params, cb)
 me(cb)
+merge(id, targetId, cb)
 ```
 
 ### userfields

--- a/lib/client/users.js
+++ b/lib/client/users.js
@@ -75,3 +75,7 @@ Users.prototype.search = function (params, cb) {
 Users.prototype.me = function (cb) {
   this.request('GET', ['users', 'me'], cb);
 };
+
+Users.prototype.merge = function (id, targetId, cb) {
+  this.request('PUT', ['users', id, 'merge'], {"user": {"id": targetId} }, cb);
+};


### PR DESCRIPTION
Added support for `users.merge` API call:
&nbsp; &nbsp; https://developer.zendesk.com/rest_api/docs/core/users#merge-users

Fixes #47