### PR TITLE
Fix the whole `useridentities` API by correcting the base URI

### DIFF
--- a/lib/client/useridentities.js
+++ b/lib/client/useridentities.js
@@ -18,39 +18,46 @@ util.inherits(UserIdentities, Client);
 // ######################################################## UserIdentities
 // ====================================== Listing UserIdentities
 UserIdentities.prototype.list = function (userID, cb) {
-  this.requestAll('GET', ['user', userID, 'identities'], cb);//all
+  this.requestAll('GET', ['users', userID, 'identities'], cb);//all
 };
 
 
 // ====================================== Viewing UserIdentities
 UserIdentities.prototype.show = function (userID, userIDentityID, cb) {
-  this.request('GET', ['user', userID, 'identities', userIDentityID], cb);
+  this.request('GET', ['users', userID, 'identities', userIDentityID], cb);
 };
 
 // ====================================== Creating UserIdentities
 UserIdentities.prototype.create = function (userID, userIDentity, cb) {
-  this.request('POST', ['user', userID, 'identities'], userIDentity, cb);
+  if (
+    userIDentity && typeof userIDentity === "object" &&
+    !Array.isArray(userIDentity) &&
+    !userIDentity.hasOwnProperty("identity")
+  ) {
+    userIDentity = {"identity": userIDentity};
+  }
+  this.request('POST', ['users', userID, 'identities'], userIDentity, cb);
 };
 
 // ====================================== Updating UserIdentities
 
 UserIdentities.prototype.update = function (userID, userIDentityID, cb) {
-  this.request('PUT', ['user', userID, 'identities', userIDentityID], {"identity": {"verified": true}}, cb);
+  this.request('PUT', ['users', userID, 'identities', userIDentityID], {"identity": {"verified": true}}, cb);
 };
 
 UserIdentities.prototype.makePrimary = function (userID, userIDentityID,  cb) {
-  this.request('PUT', ['user', userID, 'identities', userIDentityID, "make_primary"],   cb);
+  this.request('PUT', ['users', userID, 'identities', userIDentityID, "make_primary"],   cb);
 };
 
 UserIdentities.prototype.verify = function (userID, userIDentityID, cb) {
-  this.request('PUT', ['user', userID, 'identities', userIDentityID, 'verify'],   cb);
+  this.request('PUT', ['users', userID, 'identities', userIDentityID, 'verify'],   cb);
 };
 
 UserIdentities.prototype.requestVerification = function (userID, userIDentityID, cb) {
-  this.request('PUT', ['user', userID, 'identities', userIDentityID, 'request_verification'],   cb);
+  this.request('PUT', ['users', userID, 'identities', userIDentityID, 'request_verification'],   cb);
 };
 
 // ====================================== Deleting UserIdentities
 UserIdentities.prototype.delete = function (userID, userIDentityID, cb) {
-  this.request('DELETE', ['user', userID, 'identities', userIDentityID],  cb);
+  this.request('DELETE', ['users', userID, 'identities', userIDentityID],  cb);
 };


### PR DESCRIPTION
The `useridentities` part of the API was using a base URI that included an incorrect prefix `/user/` rather than the correct prefix `/users/`.

Also detect if a wrapper object needs to be added for the `useridentities.create` API call. That one was burning me for probably an hour yesterday as the Zendesk API docs aren't exactly stellar.