### PR TITLE
Fix 'undefined' being used as a query string

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -252,25 +252,30 @@ function requestCallback(self, err, response, result, callback) {
 }
 
 function assembleUrl(self, uri) {
-  var params, lastElement;
+  var lastElement,
+      params = '';
 
   if ('object' === typeof uri && Array.isArray(uri)) {
     lastElement = uri.pop();
-    if ('object' === typeof lastElement) {// we have recieved an object ex. {"sort_by":"id","sort_order":"desc"}
-      params = '?' + qs.stringify(lastElement);
-    } else { // we have recieved a query string ex. '?sort_by=id&sort_order=desc'
-      if (0 === lastElement.toString().indexOf('?')) {
+    if (lastElement) {
+      // we have received an object ex. {"sort_by":"id","sort_order":"desc"}
+      if ('object' === typeof lastElement) {
+        params = '?' + qs.stringify(lastElement);
+      }
+      // we have received a query string ex. '?sort_by=id&sort_order=desc'
+      else if (0 === lastElement.toString().indexOf('?')) {
         params = lastElement;
-      } else {
+      }
+      else {
         uri.push(lastElement);
       }
     }
     return self.options.get('remoteUri') + '/' + uri.join('/') + '.json' + params;
-  } else {
-    if (uri.indexOf(self.options.get('remoteUri')) === -1) {
-      return self.options.get('remoteUri') + uri;
-    } else {
-      return uri;
-    }
+  }
+  else if ('string' === typeof uri && uri.indexOf(self.options.get('remoteUri')) === -1) {
+    return self.options.get('remoteUri') + uri;
+  }
+  else {
+    return uri;
   }
 }


### PR DESCRIPTION
I upgraded to the latest version of this module.  I was having some issues with the Zendesk API calls, so I started doing some request debugging and found that the URLs that didn't need a query string were ended up having the word "undefined" tacked on the end where the query string would normally go, e.g.

```
https://{subdomain}.zendesk.com/api/v2/users/{user_id}/merge.jsonundefined
```

Ironically, most of the calls still seem to succeed (response status 200).  A few calls don't (response status 404) but I think that's a different issue (see PR #50).