### PR TITLE
Working implementation of request throttling

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -11,6 +11,7 @@ var fs           = require('fs'),
     async        = require('async'),
     path         = require('path'),
     flatten      = require('flatten'),
+    throttler    = require('./throttle'),
     pjson        = require('./../../package.json'),
     failCodes = {
       400: 'Bad Request',
@@ -65,7 +66,8 @@ Client.prototype.request = function (method, uri) {
       encoded  = new Buffer(this.options.get('username') + auth).toString('base64'),
       proxy    = this.options.get('proxy'),
       useOAuth = this.options.get('oauth'),
-      token    = this.options.get('token');
+      token    = this.options.get('token'),
+      throttle = this.options.get('throttle');
 
   url = assembleUrl(self, uri);
 
@@ -99,6 +101,10 @@ Client.prototype.request = function (method, uri) {
   }
 
   self.emit('debug::request', self.options);
+
+  if ( throttle ) {
+    this._request = throttle( this._request, throttle );
+  }
 
   return this._request(self.options, function (err, response, result) {
     requestCallback(self, err, response, result, callback);

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -66,8 +66,7 @@ Client.prototype.request = function (method, uri) {
       encoded  = new Buffer(this.options.get('username') + auth).toString('base64'),
       proxy    = this.options.get('proxy'),
       useOAuth = this.options.get('oauth'),
-      token    = this.options.get('token'),
-      throttle = this.options.get('throttle');
+      token    = this.options.get('token');
 
   url = assembleUrl(self, uri);
 
@@ -102,10 +101,6 @@ Client.prototype.request = function (method, uri) {
 
   self.emit('debug::request', self.options);
 
-  if ( throttle ) {
-    this._request = throttle( this._request, throttle );
-  }
-
   return this._request(self.options, function (err, response, result) {
     requestCallback(self, err, response, result, callback);
   });
@@ -119,9 +114,15 @@ Client.prototype.requestAll = function (method, uri) {
       statusList   = [],
       responseList = [],
       resultList   = [],
-      self         = this;
+      self         = this,
+      throttle     = this.options.get('throttle'),
+      __request = Client.prototype.request;
 
-  return Client.prototype.request.apply(this, args.concat(function (error, status, body, response, result) {
+  if ( throttle ) {
+     __request = throttler( this, Client.prototype.request, throttle );
+  }
+
+  return __request.apply(this, args.concat(function (error, status, body, response, result) {
     if (error) {
       return callback(error);
     }
@@ -135,7 +136,7 @@ Client.prototype.requestAll = function (method, uri) {
     async.whilst(
       function () {return null !== nextPage && 'undefined' !==  typeof nextPage; },
       function (cb) {
-        Client.prototype.request.apply(self, ['GET', nextPage, function (error, status, body, response, result) {
+        __request.apply(self, ['GET', nextPage, function (error, status, body, response, result) {
           if (error) {
             return cb(error);
           }

--- a/lib/client/throttle.js
+++ b/lib/client/throttle.js
@@ -4,8 +4,12 @@ from https://github.com/Raynos/throttle-function/blob/patch-1/index.js
 
 module.exports = throttle;
 
-function throttle(fn, opts) {
-	opts = opts || {};
+function throttle() { /* [?thisArg], fn, opts */
+	var argmts = [].slice.call( arguments );
+	var thisarg = argmts.length > 2 ? argmts.shift() : null;
+	var fn = argmts[ 0 ];
+	var opts = argmts[ 1 ] || {};
+
 	var timer;
 	var queue = [];
 	var errMsg = 'Must pass options or milliseconds as second argument';
@@ -51,7 +55,6 @@ function throttle(fn, opts) {
 			clearInterval(timer);
 			timer = null;
 		}
-		var thisarg = args.shift();
 
 		var result = fn.apply(thisarg, args);
 		return result;

--- a/lib/client/throttle.js
+++ b/lib/client/throttle.js
@@ -1,0 +1,73 @@
+/*
+from https://github.com/Raynos/throttle-function/blob/patch-1/index.js
+*/
+
+module.exports = throttle;
+
+function throttle(fn, opts) {
+	opts = opts || {};
+	var timer;
+	var queue = [];
+	var errMsg = 'Must pass options or milliseconds as second argument';
+	if (!opts)
+		throw new Error(errMsg);
+
+	var msBetweenCalls;
+
+	if (typeof opts == 'string')
+		msBetweenCalls = Number(opts);
+
+	else if (typeof opts == 'number')
+		msBetweenCalls = opts;
+
+	else {
+		var window = opts.window || 1;
+		var limit = opts.limit || 1;
+		var exact = opts.exact || false;
+		msBetweenCalls = Math.ceil((window / limit) * 1000);
+	}
+
+	if (isNaN(msBetweenCalls))
+		throw new Error(errMsg);
+
+	function enqueue(args) {
+		return queue.push(args);
+	}
+
+	function dequeue() {
+		return queue.shift();
+	}
+
+	function kickQueue() {
+		if (timer) return timer;
+		timer = setInterval(runQueue, msBetweenCalls);
+		return timer;
+	}
+
+	function runQueue() {
+		var args = dequeue();
+
+		if (queue.length === 0 || !args) {
+			clearInterval(timer);
+			timer = null;
+		}
+		var thisarg = args.shift();
+
+		var result = fn.apply(thisarg, args);
+		return result;
+	}
+
+	var throttled = function () {
+		var args = [].slice.call(arguments);
+		var position = enqueue(args);
+		var timer = kickQueue();
+
+		return {
+			position: position,
+			queuedAt: Date.now(),
+			timeUntilCall: position * msBetweenCalls
+		};
+	};
+
+	return throttled;
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "test": "node ./test/*-test.js"
   },
   "author": "Farrin Reid <blakmatrix@gmail.com>",
+  "contributors": [
+    "Eric Davis <iconecd@noreply.users.github.com>"
+  ],
   "dependencies": {
     "request": "2.51.x",
     "querystring": "0.2.x",


### PR DESCRIPTION
The throttle function I found and referenced in #62 is an es5 port of an es6 function that I hacked some  context respect into [passing in thisArg instead of calling fn.apply(null, blah) ]. I don't truly expect it to be the best function to handle the task, but this is a working implementation of throttling inside Client.prototype.requestAll

Throttling configuration is explained poorly at the original source of the library. Here goes nothing.
The throttle option can be a number, a string that evaluates via Number(), or an object with the keys 'window' and 'limit', both containing numeric values. Window is the number of seconds within which to allow the Limit of request; for the typical zendesk API customer, that would work out to ```{ window: 60, limit: 200 }```