### PR TITLE
'reply-after' header currently as Name-Case and seems invalid

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -200,7 +200,7 @@ function checkRequestResponse(self, response, result, callback) {
 
   self.emit('debug::response', {statusCode: statusCode, result: result});
 
-  retryAfter = response.headers['Retry-After'];
+  retryAfter = response.headers['retry-after'];
   if (retryAfter) {
     error = new Error('Zendesk rate limits 200 requests per minute');
     error.statusCode = 429;

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -204,7 +204,8 @@ function checkRequestResponse(self, response, result, callback) {
   if (retryAfter) {
     error = new Error('Zendesk rate limits 200 requests per minute');
     error.statusCode = 429;
-    error.result = retryAfter;
+    error.result = result;
+    error.retryAfter = retryAfter;
     return callback(error);
   }
 
@@ -212,6 +213,7 @@ function checkRequestResponse(self, response, result, callback) {
     error = new Error('Zendesk Error (' + statusCode + '): ' + failCodes[statusCode]);
     error.statusCode = statusCode;
     error.result = result;
+    error.retryAfter = null;
     return callback(error);
   }
 


### PR DESCRIPTION
I have just been running into some issues posting large numbers of comments to a single ticket and the current version of this library seems to have the formatting wrong for the 'reply-after' header.  A sample header that I am seeing get returned is as follows:
```
{ server: 'nginx',
  date: 'Thu, 26 Mar 2015 01:51:47 GMT',
  'content-type': 'application/json; charset=UTF-8',
  'content-length': '134',
  connection: 'keep-alive',
  status: '429',
  'x-zendesk-api-version': 'v2',
  'x-frame-options': 'SAMEORIGIN',
  'retry-after': '493',
  'x-zendesk-origin-server': 'xxxxxxx.zdsys.com',
  'x-ua-compatible': 'IE=Edge,chrome=1',
  'cache-control': 'no-cache',
  'x-request-id': 'xxxxxxx',
  'x-runtime': '0.134830',
  'x-rack-cache': 'invalidate, pass',
  'x-zendesk-request-id': 'xxxxxxx' }
```