### PR TITLE
Add multiple client connection support that only relies on the createCli...

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -53,28 +53,24 @@ exports.createClient = function (options) {
 
   options = store.defaults(options);
 
-  if (nconf.get('helpcenter')) {
-    this.helpcenter = true;
-  } else if (nconf.get('voice')) {
-    this.voice = true;
-  }
-
   if (nconf.get('subdomain')) {
-    if (this.helpcenter) {
-      nconf.set('remoteUri', 'https://' + nconf.get('subdomain') + '.zendesk.com/api/v2/help_center');
-    } else if (this.voice){
-      nconf.overrides({'remoteUri': 'https://'+nconf.get('subdomain') + '.zendesk.com/api/v2/channels/voice'});
+    var endpoint;
+    if (options.stores.defaults.store.helpcenter) {
+      endpoint = '.zendesk.com/api/v2/help_center';
+    } else if (options.stores.defaults.store.voice){
+      endpoint = '.zendesk.com/api/v2/channels/voice';
     } else {
-      nconf.set('remoteUri', 'https://' + nconf.get('subdomain') + '.zendesk.com/api/v2');
+      endpoint = '.zendesk.com/api/v2';
     }
+    options.stores.defaults.store.remoteUri = 'https://' + nconf.get('subdomain') + endpoint;
   }
 
   var client = {}, partsToAdd, clientPath;
 
-  if (this.helpcenter) {
+  if (options.stores.defaults.store.helpcenter) {
     partsToAdd = helpcenterParts;
     clientPath = './client/helpcenter/';
-  } else if (this.voice) {
+  } else if (options.stores.defaults.store.voice) {
     partsToAdd = voiceParts;
     clientPath = './client/voice/';
   } else {
@@ -98,5 +94,6 @@ exports.createClient = function (options) {
       console.log(args);
     }
   }
+
   return client;
 };


### PR DESCRIPTION
...ent object (not the environment variables)

Hopefully this gives more flexibility to those who want to use the core, voice, help center endpoints within the same app. It felt limiting with how the client was built before, but perhaps I have a different perspective.