### PR TITLE
Add condition for when nextPage is undefined

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -134,7 +134,14 @@ Client.prototype.requestAll = function (method, uri) {
     nextPage = result.next_page;
 
     async.whilst(
-      function () {return null !== nextPage && 'undefined' !==  typeof nextPage; },
+      function () {
+        if (null !== nextPage && 'undefined' !== typeof nextPage) {
+          return nextPage;
+        } else {
+          nextPage = '';
+          return nextPage;
+        }
+      },
       function (cb) {
         __request.apply(self, ['GET', nextPage, function (error, status, body, response, result) {
           if (error) {


### PR DESCRIPTION
Not sure if this the right spot, but we've had a few issues where next_page is undefined. I'll see if I can get more information from the logs, but this is what I have so far.

`TypeError: Cannot read property 'next_page' of undefined
    at /usr/local/zen_project/node_modules/node-zendesk/lib/client/client.js:127:22
    at /usr/local/zen_project/node_modules/node-zendesk/lib/client/client.js:249:12
    at checkRequestResponse (/usr/local/zen_project/node_modules/node-zendesk/lib/client/client.js:218:10)
    at requestCallback (/usr/local/zen_project/node_modules/node-zendesk/lib/client/client.js:226:3)
    at Request._callback (/usr/local/zen_project/node_modules/node-zendesk/lib/client/client.js:104:5)
    at Request.self.callback (/usr/local/zen_project/node_modules/node-zendesk/node_modules/request/request.js:373:22)
    at Request.emit (events.js:98:17)
    at Request.<anonymous> (/usr/local/zen_project/node_modules/node-zendesk/node_modules/request/request.js:1318:14)
    at Request.emit (events.js:117:20)`