### PR TITLE
Include other update option for article

### DIFF
--- a/lib/client/helpcenter/articles.js
+++ b/lib/client/helpcenter/articles.js
@@ -68,6 +68,12 @@ Articles.prototype.update = function (articleID, article, cb) {
   this.request('PUT', ['articles', articleID], article, cb);
 };
 
+// ====================================== Updating Articles by Locale
+
+Articles.prototype.updateByLocale = function (locale, articleID, article, cb) {
+  this.request('PUT', [locale, 'articles', articleID], article, cb);
+};
+
 // ====================================== Deleting Articles
 Articles.prototype.delete = function (articleID, cb) {
   this.request('DELETE', ['articles', articleID],  cb);


### PR DESCRIPTION
There was a missing option to update articles. You can either do it to ALL articles by their id, or you can update to an id within a locale. 

See docs for further info - https://developer.zendesk.com/rest_api/docs/help_center/articles#update-article