### PR TITLE
Updating Translations For A Category

### DIFF
--- a/lib/client/helpcenter/translations.js
+++ b/lib/client/helpcenter/translations.js
@@ -75,9 +75,14 @@ Translations.prototype.updateForArticle = function (articleID, locale, translati
   this.request('PUT', ['articles',articleID,'translations',locale], translation, cb);
 };
 
-// ====================================== Updating Translations For A Sectioon
+// ====================================== Updating Translations For A Section
 Translations.prototype.updateForSection = function (sectionID, locale, translation, cb) {
   this.request('PUT', ['sections',sectionID,'translations',locale], translation, cb);
+};
+
+// ====================================== Updating Translations For A Category
+Translations.prototype.updateForCategory = function (categoryID, locale, translation, cb) {
+  this.request('PUT', ['categories',categoryID,'translations',locale], translation, cb);
 };
 
 // ====================================== Deleting Translations


### PR DESCRIPTION
This pull request adds missing methods for updating the translation for the specified section.

Corresponding API reference:
https://developer.zendesk.com/rest_api/docs/help_center/translations#update-translation