### PR TITLE
Add macros.listByParams and macros.categories as methods

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -245,8 +245,13 @@ current(cb)
 
 ```js
 list(cb)
+listByParams(params, cb)
 apply(macroID, cb)
 applyTicket(ticketID, macroID, cb)
+create(macro, cb)
+categories(cb)
+update(macroID, macro, cb)
+createMany(users, cb)
 ```
 
 ### oauthtokens

--- a/lib/client/macros.js
+++ b/lib/client/macros.js
@@ -20,6 +20,10 @@ Macros.prototype.list = function (cb) {
   this.requestAll('GET', ['macros', 'active'], cb);//all
 };
 
+Macros.prototype.listByParams = function (params, cb) {
+  this.requestAll('GET', ['macros', params], cb);
+};
+
 Macros.prototype.apply = function (macroID, cb) {
   this.request('GET', ['macros', macroID, 'apply'], cb);//all
 };
@@ -29,6 +33,10 @@ Macros.prototype.applyTicket = function (ticketID, macroID, cb) {
 
 Macros.prototype.create = function (macro, cb) {
   this.request('POST', ['macros'], macro, cb);
+};
+
+Macros.prototype.categories = function (cb) {
+  this.requestAll('GET', ['macros', 'categories'], cb);
 };
 
 // ====================================== Updating Tickets Fields


### PR DESCRIPTION
I recently discovered that the GET macros endpoint allows for some params.

|param|type|details|
|---|---|---|
| category  | string  | Only macros within given category.  |
|  group_id |  integer |  Only macros belonging to given group. |
|  sort_by | string  | 'alphabetical', 'created_at', 'updated_at', usage_1h', 'usage_24h', or 'usage_7d'. Defaults to 'alphabetical'.  |
|  sort_order | string  | 'asc' or 'desc'. Defaults to 'asc' for 'alphabetical' sort_by, 'desc' for all others.  |

Thus I think we should add a macros.listByParams method.

In a similar way, I think we should add a macros.categories method (as seen here -- https://developer.zendesk.com/rest_api/docs/core/macros#list-macro-categories)