### PR TITLE
Fixes state issue where options were being shared between requests

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -55,7 +55,11 @@ Client = exports.Client = function (options) {
 util.inherits(Client, EventEmitter);
 
 Client.prototype.request = function (method, uri) {
-  var options, url, self = this, res, args = Array.prototype.slice.call(arguments),
+  var options = Object.assign({}, this.options),
+      url,
+      self = this,
+      res,
+      args = Array.prototype.slice.call(arguments),
       callback = args.pop(),
       body     = 'object' === typeof args[args.length - 1] && !Array.isArray(args[args.length - 1]) && args.pop(),
       auth     = this.options.get('password') ? ':' + this.options.get('password') : '/token:' + this.options.get('token'),
@@ -66,38 +70,33 @@ Client.prototype.request = function (method, uri) {
 
   url = assembleUrl(self, uri);
 
-  if (options) { // is this ever used?
-    self.options.headers = options;
-  } else {
-    self.options.headers = {
-      'Content-Type': 'application/json',
-      'Accept':       'application/json',
-      'User-Agent':   self.userAgent
-    };
-  }
+  options.headers = {
+    'Content-Type': 'application/json',
+    'Accept':       'application/json',
+    'User-Agent':   self.userAgent
+  };
 
   if (useOAuth) {// token is an oauth token obtained from OAuth2
-    self.options.headers.Authorization = 'Bearer ' + token;
+    options.headers.Authorization = 'Bearer ' + token;
   } else {// token is an API token obtained from the Zendesk Settings UI
-    self.options.headers.Authorization = 'Basic ' + encoded;
+    options.headers.Authorization = 'Basic ' + encoded;
   }
 
-  self.options.uri = url;
-  self.options.method = method || 'GET';
+  options.uri = url;
+  options.method = method || 'GET';
 
   if (body) {
-    self.options.body = JSON.stringify(body);
-  } else if ('GET' !== method && 'application/json' === self.options.headers['Content-Type']) {
-    self.options.body = '{}';
+    options.body = JSON.stringify(body);
+  } else if ('GET' !== method && 'application/json' === options.headers['Content-Type']) {
+    options.body = '{}';
   }
 
   if (proxy) {
-    self.options.proxy = proxy;
+    options.proxy = proxy;
   }
 
-  self.emit('debug::request', self.options);
-
-  return this._request(self.options, function (err, response, result) {
+  self.emit('debug::request', options);
+  return this._request(options, function (err, response, result) {
     requestCallback(self, err, response, result, callback);
   });
 };
@@ -170,20 +169,22 @@ Client.prototype.requestUpload = function (uri, file, callback) {
       encoded  = new Buffer(this.options.get('username') + auth).toString('base64'),
       useOAuth = this.options.get('oauth'),
       token    = this.options.get('token'),
-      uploadOptions = self.options;
+      options  = Object.assign({}, this.options);
 
-  self.options.uri = assembleUrl(self, uri);
-  self.options.method = 'POST';
+  options.uri = assembleUrl(self, uri);
+  options.method = 'POST';
 
-  self.options.headers = {};
+  options.headers = {};
 
   if (useOAuth) {
-    self.options.headers.Authorization = 'Bearer ' + token;
+    options.headers.Authorization = 'Bearer ' + token;
   } else {
-    self.options.headers.Authorization = 'Basic ' + encoded;
+    options.headers.Authorization = 'Basic ' + encoded;
   }
 
-  out = this._request(self.options, function (err, response, result) {
+
+  self.emit('debug::request', options);
+  out = this._request(options, function (err, response, result) {
     requestCallback(self, err, response, result, callback);
   });
 


### PR DESCRIPTION
Hello, 

Probably should have reported this as an issue first, but I was having trouble using the attachment upload APIs along with comments.

Poked around the base Client class and found that request options where being shared between the different request methods. So uploading an attachment, and then using the comment API for instance would "poison" the options for `requestUpload`, so subsequent requests would throw a stream exception `[Error: write after end]`.

I can produce an example if necessary, but all this PR does is grab the shared options, and clone them into a local var. Problem solved!