### PR TITLE
Fix ticketaudits list command

### DIFF
--- a/lib/client/ticketaudits.js
+++ b/lib/client/ticketaudits.js
@@ -21,5 +21,5 @@ util.inherits(TicketAudits, Client);
 // ######################################################## TicketAudits
 // ====================================== Listing TicketAudits
 TicketAudits.prototype.list = function (ticketID, cb) {
-  this.requestAll('GET', ['tickets', ticketID, 'audit'], cb);//all?
+  this.requestAll('GET', ['tickets', ticketID, 'audits'], cb);//all?
 };


### PR DESCRIPTION
Listing ticket audits does not work as the url was missing an "s"

Reference: https://developer.zendesk.com/rest_api/docs/core/ticket_audits#listing-audits