### PR TITLE
Fix request keep-alive issue

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -37,7 +37,8 @@ Client = exports.Client = function (options) {
     encoding: this.options.get('encoding') || null,
     timeout:  this.options.get('timeout')  || 240000,
     proxy:    this.options.get('proxy')    || null,
-    secureOptions: constants.SSL_OP_NO_TLSv1_2
+    secureOptions: constants.SSL_OP_NO_TLSv1_2,
+    forever: true
   });
 
   if (!this.jsonAPINames) {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "David Kapell <dkapell@noreply.users.github.com>"
   ],
   "dependencies": {
-    "request": "2.51.x",
+    "request": "2.67.x",
     "querystring": "0.2.x",
     "async": "0.9.x",
     "flatten": "0.0.x",


### PR DESCRIPTION
This PR tries to fix #110 (ECONNRESET for node v4 and node v5 when responses are large/require multiple requests) : 
after using the examples given by the other users I've tried to tweak the request client options a bit, and it seemed to be a keep alive handling issue, so I updated request to 2.67.x , as an option called 'forever' has been introduced since the 2.51.x previously used by node-zendesk. I've attached the test code which I used (the view has to include many tickets (over 100) for the issue to start appearing, and it disappears after I switched to forever: true on the request client)

````js
var zendesk = require('../lib/client.js');

var username = 'xxx';
var token = 'x';
var uri = 'xxx';
var viewId = 123456789;

var client = zendesk.createClient({
  username: username,
  token: token,
  remoteUri: uri
});

client.views.tickets(viewId, function (err, statusList, body) {
  if (err) {
    return console.log('request fail:', err);
  }

  console.log(body);
});
````