### PR TITLE
Add .npmignore file, update examples to look up exampleConfig

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.DS_Store
+npm-debug.log
+node_modules
+examples/
+doc/

--- a/examples/check-auth-token.js
+++ b/examples/check-auth-token.js
@@ -1,10 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  'username',
-  token:     'token',
-  remoteUri: 'https://remote.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 client.users.auth(function (err, req, result) {

--- a/examples/check-auth.js
+++ b/examples/check-auth.js
@@ -1,11 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  //debug:     true,
-  username:  'username',
-  password:  'password',
-  remoteUri: 'https://remote.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 client.users.auth(function (err, res, result) {

--- a/examples/check-oauth-token.js
+++ b/examples/check-oauth-token.js
@@ -1,10 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  'username',
-  token:     'oauth_token',
-  remoteUri: 'https://remote.zendesk.com/api/v2',
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri,
   oauth: true
 });
 

--- a/examples/exampleConfig.js
+++ b/examples/exampleConfig.js
@@ -1,0 +1,5 @@
+exports.auth = {
+  username: 'example@zendesk.com',
+  token: '',
+  remoteUri: 'https://example.zendesk.com/api/v2'
+};

--- a/examples/organization-fields-list.js
+++ b/examples/organization-fields-list.js
@@ -1,10 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username: process.env.ZENDESK_USERNAME,
-  password: process.env.ZENDESK_API_TOKEN,
-  remoteUri: process.env.ZENDESK_REMOTE_URI
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 client.organizationfields.list(function (err, statusList, body, responseList, resultList) {

--- a/examples/search-query.js
+++ b/examples/search-query.js
@@ -1,13 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs'),
-    subdomain = 'remote',
-    username  = 'username',
-    token     = 'token';
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  username,
-  token:     token,
-  remoteUri: 'https://'+subdomain+'.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 var query = "status<solved+requester:user@domain.com+type:ticket";

--- a/examples/ticket-create.js
+++ b/examples/ticket-create.js
@@ -1,19 +1,22 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  'username',
-  token:     'token',
-  remoteUri: 'https://remote.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 var ticket = {
-               "ticket":
-                 {
-                   "subject":"My printer is on fire!", 
-                   "comment": { "body": "The smoke is very colorful." }
-                 }
-             };
+  "ticket":
+    {
+      "subject":"My printer is on fire!",
+      "comment": {
+        "body": "The smoke is very colorful."
+      }
+    }
+  };
 
 client.tickets.create(ticket,  function(err, req, result) {
   if (err) return handleError(err);

--- a/examples/ticket-delete.js
+++ b/examples/ticket-delete.js
@@ -1,8 +1,12 @@
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
 var zd = require('../lib/client');
 
-
-// note: credentials given via command line arguments, like
-//       $ node examples/ticket-delete.js --debug --subdomain <company> --username <user> --token <token> --password <pw>
+var client = zd.createClient({
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
+});
 
 var ticketId = 12345;
 var client = zd.createClient();

--- a/examples/ticket-list.js
+++ b/examples/ticket-list.js
@@ -1,10 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  'username',
-  token:     'token',
-  remoteUri: 'https://remote.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 client.tickets.list(function (err, statusList, body, responseList, resultList) {

--- a/examples/upload-attachment.js
+++ b/examples/upload-attachment.js
@@ -1,19 +1,19 @@
-// upload-attachment.js - example to upload an attachment
-'use strict';
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
-var zd = require('../lib/client'),
-    path = require('path'),
-client = zd.createClient({
-  username:  'username',
-  token:     'token',
-  remoteUri: 'https://remote.zendesk.com/api/v2'
+var client = zd.createClient({
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
+
+/* Optionally add prop token to associate attachment with upload */
 
 client.attachments.upload(path.resolve(
   './examples/busey.gif'),
   {
-    filename: 'busey.gif' //,
-    //token: 'tokenROFL' // set to apply to record
+    filename: 'busey.gif'
   },
   function (err, req, result) {
     if (err) {

--- a/examples/user-create-many.js
+++ b/examples/user-create-many.js
@@ -1,13 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs'),
-    subdomain = 'remote',
-    username  = 'username',
-    token     = 'token';
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  username,
-  token:     token,
-  remoteUri: 'https://'+subdomain+'.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 

--- a/examples/user-create.js
+++ b/examples/user-create.js
@@ -1,13 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs'),
-    subdomain = 'remote',
-    username  = 'username',
-    token     = 'token';
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  username,
-  token:     token,
-  remoteUri: 'https://'+subdomain+'.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 var user = {

--- a/examples/user-fields-list.js
+++ b/examples/user-fields-list.js
@@ -1,10 +1,12 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+console.log(exampleConfig);
+var fs = require('fs');
+var zd = require('../lib/client')
 
 var client = zd.createClient({
-  username: process.env.ZENDESK_USERNAME,
-  password: process.env.ZENDESK_API_TOKEN,
-  remoteUri: process.env.ZENDESK_REMOTE_URI
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 client.userfields.list(function (err, req, result) {

--- a/examples/users-list.js
+++ b/examples/users-list.js
@@ -1,10 +1,11 @@
-var zd = require('../lib/client'),
-    fs = require('fs');
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
 
 var client = zd.createClient({
-  username:  'username',
-  token:     'token',
-  remoteUri: 'https://remote.zendesk.com/api/v2'
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
 });
 
 client.users.list(function (err, req, result) {


### PR DESCRIPTION
I want to centralize the auth configuration for all examples.

Also, let's not publish the `/examples` or `/doc` directories to npm anymore.