### PR TITLE
Remove dependency on flatten and instead use a native function

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -10,7 +10,6 @@ var fs           = require('fs'),
     qs           = require('querystring'),
     async        = require('async'),
     path         = require('path'),
-    flatten      = require('flatten'),
     throttler    = require('./throttle'),
     pjson        = require('./../../package.json'),
     failCodes = {
@@ -365,4 +364,16 @@ function assembleUrl(self, uri) {
   else {
     return uri;
   }
+}
+
+function flatten(array) {
+  var ret = [];
+  for (var i in array) {
+    if (Array.isArray(array[i])) {
+      ret = ret.concat(flatten(array[i]));
+    } else {
+      ret.push(ary[i]);
+    }
+  }
+  return ret;
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "request": "2.67.x",
     "querystring": "0.2.x",
     "async": "0.9.x",
-    "flatten": "0.0.x",
     "nconf": "0.7.x"
   }
 }


### PR DESCRIPTION
The recent left-pad dependency issue made me wonder if this project should reduce the amount of "utility" or one-thing dependencies. 

This PR is more of an open question. Should this project consider reducing the number of dependencies?

With this PR in mind, we would be at 4 dependencies.

```
  "dependencies": {
    "request": "2.67.x",
    "querystring": "0.2.x",
    "async": "0.9.x",
    "nconf": "0.7.x"
  }
```
