### PR TITLE
passes the same options to createClient that are passed for a

### DIFF
--- a/lib/client/helpers.js
+++ b/lib/client/helpers.js
@@ -16,7 +16,7 @@ exports.defaultUser = function (appName) {
 exports.getJobStatuses = function(options, jobID, interval, maxAttempts, cb) {
   var nIntervId, // Interval handle
       attempts = 0,
-      client = require('../client').createClient(options);
+      client = require('../client').createClient(options.stores.defaults.store);
   nIntervId = setInterval(function getJobStatusUntilComplete() { getJobStatus(jobID); },( interval||500));
 
 
@@ -28,7 +28,9 @@ exports.getJobStatuses = function(options, jobID, interval, maxAttempts, cb) {
       } else {
         if(err){clearInterval(nIntervId); return cb(err);}// Error
 
-        if(result["job_status"].status === "completed"){
+        if(result["job_status"].status === "completed" ||
+             result["job_status"].status === "failed" || 
+             result["job_status"].status === "killed") {
           stopGetJobStatus();
           console.log('Job '+id+' completed!');
           return cb(null, req, result);


### PR DESCRIPTION
"jobstatuses.show".  modified logic to call callback on "failed" and
"killed" in addition to "completed"
