### PR TITLE
Socket Hang Up Improvements

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -38,7 +38,8 @@ Client = exports.Client = function (options) {
     timeout:  this.options.get('timeout')  || 240000,
     proxy:    this.options.get('proxy')    || null,
     secureOptions: constants.SSL_OP_NO_TLSv1_2,
-    forever: true
+    forever: true,
+    pool: {maxSockets: 100}
   });
 
   if (!this.jsonAPINames) {
@@ -73,7 +74,8 @@ Client.prototype.request = function (method, uri) {
     self.options.headers = {
       'Content-Type': 'application/json',
       'Accept':       'application/json',
-      'User-Agent':   self.userAgent
+      'User-Agent':   self.userAgent,
+      'Content-Length': body.length
     };
   }
 


### PR DESCRIPTION
Was facing `{ [Error: socket hang up] code: 'ECONNRESET' }` limiting the number of sockets as explained in the [request docs](https://github.com/request/request) squashed the problem.

> A maxSockets property can also be provided on the pool object to set the max number of sockets for all agents created (ex: pool: {maxSockets: Infinity}).

Also specifying the `Content-Length` in the request header to work in tandem with the socket connections.