### PR TITLE
Adding the autocomplete endpoint for users

### DIFF
--- a/lib/client/users.js
+++ b/lib/client/users.js
@@ -112,6 +112,10 @@ Users.prototype.search = function (params, cb) {
   this.requestAll('GET', ['users', 'search', params], cb);
 };
 
+Users.prototype.autocomplete = function (params, cb) {
+  this.requestAll('GET', ['users', 'autocomplete', params], cb);
+};
+
 Users.prototype.me = function (cb) {
   this.request('GET', ['users', 'me'], cb);
 };


### PR DESCRIPTION
Hi, 

I want to use the autocomplete endpoint for users, so I just added: https://developer.zendesk.com/rest_api/docs/core/users#autocomplete-users

Regards.