### PR TITLE
bump request minor version to address deprecated tough-cookie@2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "Adil H <didil@noreply.users.github.com>"
   ],
   "dependencies": {
-    "request": "2.67.x",
+    "request": "2.74.x",
     "querystring": "0.2.x",
     "async": "0.9.x",
     "flatten": "0.0.x",


### PR DESCRIPTION
Dependency `request@2.67.1` had a dependency on `tough-cookie@2.2.2` which throws this deprecation warning:

    npm WARN deprecated tough-cookie@2.2.2: ReDoS vulnerability parsing Set-Cookie https://nodesecurity.io/advisories/130

This is fixed in `request@2.74.0`.