### PR TITLE
update to support binary files instead of absolute path uploads

### DIFF
--- a/lib/client/attachments.js
+++ b/lib/client/attachments.js
@@ -14,14 +14,15 @@ util.inherits(Attachments, Client);
 // ====================================== Creating Upload
 Attachments.prototype.upload = function (file, fileOptions, cb) {
   var fileOption = {
-    filename: fileOptions.filename
+    filename: fileOptions.filename,
+    binary: fileOptions.binary
   }
 
   /**
-  * When attaching multiple files, a token is returned in 
+  * When attaching multiple files, a token is returned in
   * the successful 201 response.
   * This token can be used in subsequent requests in order
-  * to associate other attachments with a previous upload.  
+  * to associate other attachments with a previous upload.
   * This token expires after 3 days.
   */
 

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -173,7 +173,8 @@ Client.prototype.requestUpload = function (uri, file, callback) {
       encoded  = new Buffer(this.options.get('username') + auth).toString('base64'),
       useOAuth = this.options.get('oauth'),
       token    = this.options.get('token'),
-      uploadOptions = self.options;
+      uploadOptions = self.options,
+      binary = uri[1] ? uri[1].binary : false;
 
   self.options.uri = assembleUrl(self, uri);
   self.options.method = 'POST';
@@ -185,13 +186,20 @@ Client.prototype.requestUpload = function (uri, file, callback) {
   } else {
     self.options.headers.Authorization = 'Basic ' + encoded;
   }
-
-  out = this._request(self.options, function (err, response, result) {
-    requestCallback(self, err, response, result, callback);
-  });
-
-  fs.createReadStream(file).pipe(out); // pipe the file!
-
+  self.emit('debug::request', self.options);
+  // assumes a binary file is passed in instead of a path
+  if(binary){
+    self.options.body = file;
+    return this._request(self.options, function (err, response, result) {
+      requestCallback(self, err, response, result, callback);
+    });
+  }
+  else{
+    let out = this._request(self.options, function (err, response, result) {
+      requestCallback(self, err, response, result, callback);
+    });
+    fs.createReadStream(file).pipe(out); // pipe the file!
+  }
 };
 
 Client.prototype.setSideLoad = function(arr){


### PR DESCRIPTION
Simple change to support binaryFile input instead of having to use fs.createReadStream and have the file saved locally.

This is mainly to support the use case of a user uploading a file to a form and I would like to upload it to Zendesk without having to save it to disk. In the current functionality, you had to specify an absolute path for fs.createReadStream to pick up the file. This is not ideal as I was not storing the uploaded files anywhere.

I got this to work without changes, by saving the file to disk before calling the upload method, but then ran into a 'write after end' error after the first successful file upload. If I didn't restart the server it would always fail the second time the upload call was made. It seems to be similar to [162](https://github.com/blakmatrix/node-zendesk/issues/162) and [167](https://github.com/blakmatrix/node-zendesk/issues/167)

Removing the use of fs seems to have resolved the 'write after end' issue as well as allowing me to directly upload files without having to save them. 