### PR TITLE
added method for creating oauth tokens

### DIFF
--- a/lib/client/oauthtokens.js
+++ b/lib/client/oauthtokens.js
@@ -27,3 +27,7 @@ OauthTokens.prototype.list = function (cb) {
 OauthTokens.prototype.revoke = function (id, cb) {
   this.request('DELETE', ['oauth', 'tokens', id], cb);
 };
+
+OauthTokens.prototype.create = function (token, cb) {
+  this.request('POST', ['oauth', 'tokens'], token, cb);
+};


### PR DESCRIPTION
Creating oauth tokens is available in the zendesk api but not in node-zendesk. Adding the method to node-zendesk.