### PR TITLE
Fixed: Request body leaking between consecutive API calls

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -88,7 +88,9 @@ Client.prototype.request = function (method, uri) {
   self.options.uri = url;
   self.options.method = method || 'GET';
 
-  if (body) {
+  if ('GET' === method) {
+    self.options.body = undefined;
+  } else if (body) {
     self.options.body = JSON.stringify(body);
   } else if ('GET' !== method && 'application/json' === self.options.headers['Content-Type']) {
     self.options.body = '{}';


### PR DESCRIPTION
First request going out. POST with a body.
```
  { stores:
   { defaults:
      Literal {
        type: 'literal',
        store: [Object],
        mtimes: {},
        readOnly: true,
        loadFrom: null,
        logicalSeparator: ':' } },
  sources: [],
  headers:
   { 'Content-Type': 'application/json',
     Accept: 'application/json',
     'User-Agent': 'node-zendesk/1.1.12 (node/6.10.3)',
     'Content-Length': undefined,
     Authorization: 'Redacted' },
  uri: 'https://test.zendesk.com/api/v2/users.json',
  method: 'POST',
  body: '{"user":{"email":"leaktest@test.com","phone":"+10606139343","name":"Leaky McLeakface","verified":true}}' }
```

Consecutive request, a GET with the identical request body that should not be there.
```
  { stores:
   { defaults:
      Literal {
        type: 'literal',
        store: [Object],
        mtimes: {},
        readOnly: true,
        loadFrom: null,
        logicalSeparator: ':' } },
  sources: [],
  headers:
   { 'Content-Type': 'application/json',
     Accept: 'application/json',
     'User-Agent': 'node-zendesk/1.1.12 (node/6.10.3)',
     'Content-Length': undefined,
     Authorization: 'Redacted' },
  uri: 'https://test.zendesk.com/api/v2/search.json?query=type:user+email:"leaktest@test.com"',
  method: 'GET',
  body: '{"user":{"email":"leaktest@test.com","phone":"+10606139343","name":"Leaky McLeakface","verified":true}}' }
```

This is quick fix handling most of the (my) problems, but leaks can also occur while using other verbs (delete etc)