### PR TITLE
Better readability while debugging

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -93,6 +93,9 @@ exports.createClient = function (options) {
 
   function debug(args) {
     if (options.get('debug')) {
+      if (args.result) {
+        args.result = String(args.result);
+      }
       console.log(args);
     }
   }


### PR DESCRIPTION
When debug flag is on this change produces human friendly output by type casting result key to string from buffer on response object.

From what I've gathered response is parsed at lib/client/client.js, ``checkRequestResponse()`` by attempting to use ``JSON.parse`` on the object. Since the following holds true this should not break anything.

```javascript
var json = '{ "json": true }';
assert.deepEqual(JSON.parse(new Buffer(json)), JSON.parse(json));
```