### PR TITLE
Duck type file as stream

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -172,6 +172,8 @@ redactAttachmentComment(ticketID, commentID, attachmentID, cb)
 
 fileOptions = {filename: 'file.txt', token: 'P1c4rDRuLz'}
 // token is [optional]
+
+file = // string or Stream (with 'pipe' function)
 ```
 
 ### dynamiccontent

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -210,7 +210,11 @@ Client.prototype.requestUpload = function (uri, file, callback) {
     requestCallback(self, err, response, result, callback);
   });
 
-  fs.createReadStream(file).pipe(out); // pipe the file!
+  if ( typeof file.pipe === 'function') {
+    file.pipe(out);
+  } else {
+    fs.createReadStream(file).pipe(out); // pipe the file!
+  }
 
 };
 


### PR DESCRIPTION
This PR allows the `file` variable passed in to upload to be a stream.  This allows dealing with uploads that aren't necessarily file objects.