### PR TITLE
Enable streaming / observer pattern for pagination

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -79,7 +79,7 @@ Below is a list of options you may use when calling any scripts you may have wri
 --encoding X
 ```
 
-They are fairly self-explanatory no-cookies, timeout, proxy, encoding are all options to request. if using debug its reccomended you use `--encoding utf8` or something similar as all you will see is a buffer otherwise in the response.
+They are fairly self-explanatory no-cookies, timeout, proxy, encoding are all options to request. if using debug its recommended you use `--encoding utf8` or something similar as all you will see is a buffer otherwise in the response.
 
 Because of these command line options you can try a few already from the examples section:
 
@@ -102,7 +102,7 @@ var client = zendesk.createClient({
   token:     'oauth_token',
   remoteUri: 'https://remote.zendesk.com/api/v2',
   disableGlobalState: true,
-  debug: true // if you wan't to debug in library only mode, you'll have to include this
+  debug: true // if you want to debug in library only mode, you'll have to include this
 });
 ```
 
@@ -124,6 +124,10 @@ request(method, uri)
 requestAll(method, uri) //pulls back multiple pages
 requestUpload(uri, file, fileToken, callback)
 ```
+
+## Pagination
+
+When using the `requestAll` method, the client automatically pages-through results, accumulating all responses before returning them to the `cb` method. To monitor pagination, the `cb` parameter can also be an [observer](http://reactivex.io/rxjs/manual/overview.html#observer) – see [this example](examples/ticket-list-observer.js).
 
 ## Core API Methods
 (See: https://developer.zendesk.com/rest_api/docs/core/introduction)

--- a/examples/ticket-list-observer.js
+++ b/examples/ticket-list-observer.js
@@ -1,0 +1,23 @@
+var exampleConfig = require('./exampleConfig');
+var fs = require('fs');
+var zd = require('../lib/client');
+
+var client = zd.createClient({
+  username:  exampleConfig.auth.username,
+  token:     exampleConfig.auth.token,
+  remoteUri: exampleConfig.auth.remoteUri
+});
+
+var observer = {
+  error: console.error,
+  next: function(status, body, response, result, nextPage) {
+    console.log(JSON.stringify(body, null, 2, true));
+    console.log('Next page:', nextPage);
+  },
+  complete: function(statusList, body, responseList, resultList) {
+    console.log('Pagination complete.');
+    console.log(body); //will display all tickets
+  }
+};
+
+client.tickets.list(observer);

--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -107,7 +107,7 @@ Client.prototype.request = function (method, uri) {
 
 Client.prototype.requestAll = function (method, uri) {
   var args         = Array.prototype.slice.call(arguments),
-      callback     = args.pop(),
+      callbackOpt  = args.pop(),
       nextPage     = 'Not Null!',
       bodyList     = [],
       statusList   = [],
@@ -117,21 +117,39 @@ Client.prototype.requestAll = function (method, uri) {
       throttle     = this.options.get('throttle'),
       __request = Client.prototype.request;
 
+  var errorCb, nextCb, completeCb;
+  if ( typeof callbackOpt === 'function' ) {
+    errorCb = callbackOpt;
+    nextCb = function () {};
+    completeCb = function (statusList, bodyList, responseList, resultList) {
+      callbackOpt(null, statusList, bodyList, responseList, resultList)
+    };
+  } else {
+    errorCb = callbackOpt.error;
+    nextCb = callbackOpt.next;
+    completeCb = callbackOpt.complete;
+  }
+
   if ( throttle ) {
      __request = throttler( this, Client.prototype.request, throttle );
   }
 
+  function processPage(status, body, response, result) {
+    if(completeCb) { // only accumulate pages if a completeCb is provided
+      statusList.push(status);
+      bodyList.push(body);
+      responseList.push(response);
+      resultList.push(result);
+    }
+    nextPage = result ? result.next_page : null;
+    nextCb(status, body, response, result, nextPage);    
+  }
+
   return __request.apply(this, args.concat(function (error, status, body, response, result) {
     if (error) {
-      return callback(error);
+      return errorCb(error);
     }
-
-    statusList.push(status);
-    bodyList.push(body);
-    responseList.push(response);
-    resultList.push(result);
-    nextPage = result ? result.next_page : null;
-
+    processPage(status, body, response, result);
     async.whilst(
       function () {
         if (nextPage !== null) {
@@ -146,20 +164,15 @@ Client.prototype.requestAll = function (method, uri) {
           if (error) {
             return cb(error);
           }
-
-          statusList.push(status);
-          bodyList.push(body);
-          responseList.push(response);
-          resultList.push(result);
-          nextPage = result ? result.next_page : null;
+          processPage(status, body, response, result);          
           cb(null);
         }]);
       },
       function (err) {
         if (err) {
-          callback(err);
-        } else {
-          return callback(null, statusList, flatten(bodyList), responseList, resultList);
+          return errorCb(err);
+        } else if(completeCb) {
+          return completeCb(statusList, flatten(bodyList), responseList, resultList);
         }
       }
       );


### PR DESCRIPTION
Solves #93.

This allows for an RxJS-style [observer](http://reactivex.io/rxjs/manual/overview.html#observer) interface to be used in place of a callback for methods which use `Client.prototype.requestAll`. 

Instead of waiting for pagination to finish for a result to be returned, a `next` callback can be called each time a response is received from Zendesk. The `complete` callback is called when pagination is finished.

This change is backwards-compatible. Callers can continue using the simpler, single-callback API for small result sets, while users with large result sets can use this streaming interface.