### PR TITLE
Add listWithLocale to categories (Help Center)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -661,6 +661,7 @@ delete(articleID, cb)
 
 ```js
 list(cb)
+listWithLocale(locale, cb)
 show(categoryID, cb)
 create(category, cb)
 update(categoryID, category, cb)

--- a/lib/client/helpcenter/categories.js
+++ b/lib/client/helpcenter/categories.js
@@ -23,6 +23,11 @@ Categories.prototype.list = function (cb) {
   this.requestAll('GET', ['categories'], cb);//all
 };
 
+// ====================================== Listing Categories By Locale
+Categories.prototype.listWithLocale = function (locale, cb) {
+  this.requestAll('GET', [locale, 'categories'], cb);//all
+};
+
 // ====================================== Viewing Categories
 
 Categories.prototype.show = function (categoryID, cb) {


### PR DESCRIPTION
Was missing, by the way it exists for sections (but not displayed in readme).