### PR TITLE
** Zendesk Breaking Change - update to client to not send TLS 1.0 or 1.1

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var fs           = require('fs'),
-    constants    = require('constants'),
+    constants    = require('crypto').constants,
     request      = require('request'),
     util         = require('util'),
     EventEmitter = require('events').EventEmitter,
@@ -37,7 +37,7 @@ Client = exports.Client = function (options) {
     encoding: this.options.get('encoding') || null,
     timeout:  this.options.get('timeout')  || 240000,
     proxy:    this.options.get('proxy')    || null,
-    secureOptions: constants.SSL_OP_NO_TLSv1_2,
+    secureOptions: constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_TLSv1_1,
     forever: true,
     pool: {maxSockets: 100}
   });


### PR DESCRIPTION
Per this Zendesk blog post:   https://support.zendesk.com/hc/en-us/articles/360000710347-Removal-of-support-for-TLS-protocol-versions-1-0-and-1-1

We started getting several errors this morning - Error: write EPROTO 140640287860544:error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/record/rec_layer_s3.c:1407:SSL alert number 70

This update to the request is the fix