### PR TITLE
use explicit require and export

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,76 @@
 // client.js - node-zendesk client initialization
 'use strict';
 
+// Export client classes
+exports.Users = require('./clinet/users').Users;
+exports.Tickets = require('./clinet/tickets').Tickets;
+exports.TicketAudits = require('./clinet/ticketaudits').TicketAudits;
+exports.TicketFields = require('./clinet/ticketfields').TicketFields;
+exports.TicketForms = require('./clinet/ticketforms').TicketForms;
+exports.TicketMetrics = require('./clinet/ticketmetrics').TicketMetrics;
+exports.TicketImport = require('./clinet/ticketimport').TicketImport;
+exports.TicketExport = require('./clinet/ticketexport').TicketExport;
+exports.Views = require('./clinet/views').Views;
+exports.Requests = require('./clinet/requests').Requests;
+exports.UserIdentities = require('./clinet/useridentities').UserIdentities;
+exports.Groups = require('./clinet/groups').Groups;
+exports.GroupMemberships = require('./clinet/groupmemberships').GroupMemberships;
+exports.CustomAgentRoles = require('./clinet/customagentroles').CustomAgentRoles;
+exports.Organizations = require('./clinet/organizations').Organizations;
+exports.Search = require('./clinet/search').Search;
+exports.Tags = require('./clinet/tags').Tags;
+exports.Forums = require('./clinet/forums').Forums;
+exports.ForumSubscriptions = require('./clinet/forumsubscriptions').ForumSubscriptions;
+exports.Categories = require('./clinet/categories').Categories;
+exports.Topics = require('./clinet/topics').Topics;
+exports.TopicComments = require('./clinet/topiccomments').TopicComments;
+exports.TopicSubscriptions = require('./clinet/topicsubscriptions').TopicSubscriptions;
+exports.TopicVotes = require('./clinet/topicvotes').TopicVotes;
+exports.AccountSettings = require('./clinet/accountsettings').AccountSettings;
+exports.ActivityStream = require('./clinet/activitystream').ActivityStream;
+exports.Attachments = require('./clinet/attachments').Attachments;
+exports.JobStatuses = require('./clinet/jobstatuses').JobStatuses;
+exports.Locales = require('./clinet/locales').Locales;
+exports.Macros = require('./clinet/macros').Macros;
+exports.SatisfactionRatings = require('./clinet/satisfactionratings').SatisfactionRatings;
+exports.SuspendedTickets = require('./clinet/suspendedtickets').SuspendedTickets;
+exports.UserFields = require('./clinet/userfields').UserFields;
+exports.OrganizationFields = require('./clinet/organizationfields').OrganizationFields;
+exports.OauthTokens = require('./clinet/oauthtokens').OauthTokens;
+exports.Triggers = require('./clinet/triggers').Triggers;
+exports.SharingAgreement = require('./clinet/sharingagreement').SharingAgreement;
+exports.Brand = require('./clinet/brand').Brand;
+exports.OrganizationMemberships = require('./clinet/organizationmemberships').OrganizationMemberships;
+exports.DynamicContent = require('./clinet/dynamiccontent').DynamicContent;
+exports.TicketEvents = require('./clinet/ticketevents').TicketEvents;
+exports.Imports = require('./clinet/imports').Imports;
+exports.Targets = require('./clinet/targets').Targets;
+exports.Sessions = require('./clinet/sessions').Sessions;
+exports.Installations = require('./clinet/installations').Installations;
+exports.Policies = require('./clinet/policies').Policies;
+
+// Export help center client classes
+exports.Articles = require('./client/helpcenter/articles').Articles;
+exports.Sections = require('./client/helpcenter/sections').Sections;
+exports.Categories = require('./client/helpcenter/categories').Categories;
+exports.Translations = require('./client/helpcenter/translations').Translations;
+exports.ArticleComments = require('./client/helpcenter/articlecomments').ArticleComments;
+exports.ArticleLabels = require('./client/helpcenter/articlelabels').ArticleLabels;
+exports.ArticleAttachments = require('./client/helpcenter/articleattachments').ArticleAttachments;
+exports.Votes = require('./client/helpcenter/votes').Votes;
+exports.Search = require('./client/helpcenter/search').Search;
+exports.AccessPolicies = require('./client/helpcenter/accesspolicies').AccessPolicies;
+exports.Subscriptions = require('./client/helpcenter/subscriptions').Subscriptions;
+
+// Export voice client classes
+exports.PhoneNumbers = require('./client/voice/phonenumbers').PhoneNumbers;
+exports.GreetingCategories = require('./client/voice/greetingcategories').GreetingCategories;
+exports.Greetings = require('./client/voice/greetings').Greetings;
+exports.CurrentQueueActivity = require('./client/voice/currentqueueactivity').CurrentQueueActivity;
+exports.HistoricalQueueActivity = require('./client/voice/historicalqueueactivity').HistoricalQueueActivity;
+exports.AgentActivity = require('./client/voice/agentactivity').AgentActivity;
+exports.Availabilities = require('./client/voice/availabilities').Availabilities;
+
 var parts = [
       'Users', 'Tickets', 'TicketAudits', 'TicketFields', 'TicketForms', 'TicketMetrics', 'TicketImport', 'TicketExport',
       'Views', 'Requests', 'UserIdentities', 'Groups', 'GroupMemberships',
@@ -67,23 +137,15 @@ exports.createClient = function (options) {
     options.stores.defaults.store.remoteUri = 'https://' + nconf.get('subdomain') + endpoint;
   }
 
-  var client = {}, partsToAdd, clientPath;
+  var client = {}, partsToAdd;
 
   if (options.stores.defaults.store.helpcenter) {
     partsToAdd = helpcenterParts;
-    clientPath = './client/helpcenter/';
   } else if (options.stores.defaults.store.voice) {
     partsToAdd = voiceParts;
-    clientPath = './client/voice/';
   } else {
     partsToAdd = parts;
-    clientPath = './client/';
   }
-
-
-  partsToAdd.forEach(function (k) {
-    exports[k] = require(clientPath + k.toLowerCase())[k];
-  });
 
   partsToAdd.forEach(function (k) {
     client[k.toLowerCase()] = new exports[k](options);


### PR DESCRIPTION
We are using node-zendesk as part of our lambda function. Recently we started switching our build pipeline to utilize webpack for bundling the lambda package. Unfortunately the dynamic require pattern that was used was preventing webpack from doing dependency analysis and tree-shaking.