### PR TITLE
Use Buffer.from instead of new Buffer

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -26,7 +26,6 @@ var fs           = require('fs'),
       503: 'Service Unavailable'
     };
 
-
 Client = exports.Client = function (options) {
   this.options = options;
   this.sideLoad = [];
@@ -61,7 +60,7 @@ Client.prototype.request = function (method, uri) {
       callback = args.pop(),
       body     = 'object' === typeof args[args.length - 1] && !Array.isArray(args[args.length - 1]) && args.pop(),
       auth     = this.options.get('password') ? ':' + this.options.get('password') : '/token:' + this.options.get('token'),
-      encoded  = new Buffer(this.options.get('username') + auth).toString('base64'),
+      encoded  = Buffer.from(this.options.get('username') + auth).toString('base64'),
       proxy    = this.options.get('proxy'),
       useOAuth = this.options.get('oauth'),
       token    = this.options.get('token'),
@@ -190,7 +189,7 @@ Client.prototype.requestUpload = function (uri, file, callback) {
   var self     = this,
       out,
       auth     = this.options.get('password') ? ':' + this.options.get('password') : '/token:' + this.options.get('token'),
-      encoded  = new Buffer(this.options.get('username') + auth).toString('base64'),
+      encoded  = Buffer.from(this.options.get('username') + auth).toString('base64'),
       useOAuth = this.options.get('oauth'),
       token    = this.options.get('token'),
       uploadOptions = self.options;


### PR DESCRIPTION
Was seeing this when running the client on node v10.2.1

```
eriks$ node --trace-warnings examples/users-list.js
(node:5085) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
    at showFlaggedDeprecation (buffer.js:159:11)
    at new Buffer (buffer.js:174:3)
    at exports.Users.Client.request (/Users/eriks/dev/node-zendesk/lib/client/client.js:65:18)
    at exports.Users.Client.requestAll (/Users/eriks/dev/node-zendesk/lib/client/client.js:156:20)
    at exports.Users.Users.list (/Users/eriks/dev/node-zendesk/lib/client/users.js:30:8)
    at Object.<anonymous> (/Users/eriks/dev/node-zendesk/examples/users-list.js:11:14)
    at Module._compile (internal/modules/cjs/loader.js:702:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:713:10)
    at Module.load (internal/modules/cjs/loader.js:612:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:551:12)
```