### PR TITLE
Use requestAll instead of request in incremental export methods

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -113,15 +113,17 @@ Client.prototype.request = function (method, uri) {
 };
 
 Client.prototype.requestAll = function (method, uri) {
-  var args         = Array.prototype.slice.call(arguments),
-      callbackOpt  = args.pop(),
-      nextPage     = 'Not Null!',
-      bodyList     = [],
-      statusList   = [],
-      responseList = [],
-      resultList   = [],
-      self         = this,
-      throttle     = this.options.get('throttle'),
+  var args          = Array.prototype.slice.call(arguments),
+      callbackOpt   = args.pop(),
+      nextPage      = 'Not Null!',
+      count         = -1,
+      bodyList      = [],
+      statusList    = [],
+      responseList  = [],
+      resultList    = [],
+      self          = this,
+      throttle      = this.options.get('throttle'),
+      isIncremental = uri[0] === 'incremental',
       __request = Client.prototype.request;
 
   var errorCb, nextCb, completeCb;
@@ -149,7 +151,8 @@ Client.prototype.requestAll = function (method, uri) {
       resultList.push(result);
     }
     nextPage = result ? result.next_page : null;
-    nextCb(status, body, response, result, nextPage);    
+    count = result ? result.count : 0;
+    nextCb(status, body, response, result, nextPage);
   }
 
   return __request.apply(this, args.concat(function (error, status, body, response, result) {
@@ -159,12 +162,10 @@ Client.prototype.requestAll = function (method, uri) {
     processPage(status, body, response, result);
     async.whilst(
       function () {
-        if (nextPage !== null) {
-          return nextPage;
-        } else {
-          nextPage = '';
-          return nextPage;
+        if (nextPage === null || (isIncremental && count < 1000)) {
+          nextPage =  '';
         }
+        return nextPage;
       },
       function (cb) {
         __request.apply(self, ['GET', nextPage, function (error, status, body, response, result) {

--- a/lib/client/organizations.js
+++ b/lib/client/organizations.js
@@ -63,12 +63,12 @@ Organizations.prototype.autocomplete = function (params, cb) {
 
 // ====================================== New Incremental Organization Export with include
 Organizations.prototype.incrementalInclude = function (startTime, include, cb) {
-  this.request('GET', ['incremental', 'organizations', {start_time: startTime, include: include}],  cb);
+  this.requestAll('GET', ['incremental', 'organizations', {start_time: startTime, include: include}],  cb);
 };
 
 // ====================================== New Incremental Organization Export
 Organizations.prototype.incremental = function (startTime, cb) {
-  this.request('GET', ['incremental', 'organizations', {start_time: startTime}],  cb);
+  this.requestAll('GET', ['incremental', 'organizations', {start_time: startTime}],  cb);
 };
 
 // ====================================== New Incremental Organization Export Sample

--- a/lib/client/ticketevents.js
+++ b/lib/client/ticketevents.js
@@ -18,12 +18,12 @@ util.inherits(TicketEvents, Client);
 
 //  ====================================== New Incremental TicketEvents Export with include
 TicketEvents.prototype.incrementalInclude = function (startTime, include, cb) {
-  this.request('GET', ['incremental', 'ticket_events', {start_time: startTime, include: include}],  cb);
+  this.requestAll('GET', ['incremental', 'ticket_events', {start_time: startTime, include: include}],  cb);
 };
 
 //  ====================================== New Incremental Ticket Export
 TicketEvents.prototype.incremental = function (startTime, cb) {
-  this.request('GET', ['incremental', 'ticket_events', {start_time: startTime}],  cb);
+  this.requestAll('GET', ['incremental', 'ticket_events', {start_time: startTime}],  cb);
 };
 //  ====================================== New Incremental Ticket Export Sample
 TicketEvents.prototype.incrementalSample = function (startTime, cb) {

--- a/lib/client/tickets.js
+++ b/lib/client/tickets.js
@@ -117,12 +117,12 @@ Tickets.prototype.exportSample = function (startTime, options) {
 
 //  ====================================== New Incremental Ticket Export
 Tickets.prototype.incremental = function (startTime, cb) {
-  this.request('GET', ['incremental', 'tickets', {start_time: startTime}],  cb);
+  this.requestAll('GET', ['incremental', 'tickets', {start_time: startTime}],  cb);
 };
 
 //  ====================================== New Incremental Ticket Export with include
 Tickets.prototype.incrementalInclude = function (startTime, include, cb) {
-  this.request('GET', ['incremental', 'tickets', {start_time: startTime, include: include}],  cb);
+  this.requestAll('GET', ['incremental', 'tickets', {start_time: startTime, include: include}],  cb);
 };
 
 //  ====================================== New Incremental Ticket Export Sample

--- a/lib/client/users.js
+++ b/lib/client/users.js
@@ -122,12 +122,12 @@ Users.prototype.merge = function (id, targetId, cb) {
 
 //  ====================================== New Incremental Users Export with include
 Users.prototype.incrementalInclude = function (startTime, include, cb) {
-  this.request('GET', ['incremental', 'users', {start_time: startTime, include: include}],  cb);
+  this.requestAll('GET', ['incremental', 'users', {start_time: startTime, include: include}],  cb);
 };
 
 //  ====================================== New Incremental Users Export
 Users.prototype.incremental = function (startTime, cb) {
-  this.request('GET', ['incremental', 'users', {start_time: startTime}],  cb);
+  this.requestAll('GET', ['incremental', 'users', {start_time: startTime}],  cb);
 };
 //  ====================================== New Incremental Users Export Sample
 Users.prototype.incrementalSample = function (startTime, cb) {


### PR DESCRIPTION
- This change will actually will fetch the complete delta and will not limit to 1000
- Will enable using observer method instead of using callbacks