### PR TITLE
Automatically set binary flag on file stream

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -1,7 +1,8 @@
 // client.js - main client file that does most of the processing
 'use strict';
 
-var fs           = require('fs'),
+var stream       = require('stream'),
+    fs           = require('fs'),
     constants    = require('crypto').constants,
     request      = require('request'),
     util         = require('util'),
@@ -194,7 +195,7 @@ Client.prototype.requestUpload = function (uri, file, callback) {
       useOAuth = this.options.get('oauth'),
       token    = this.options.get('token'),
       uploadOptions = self.options,
-      binary = uri[1] ? uri[1].binary : false;
+      binary = uri[1] ? (uri[1].binary || file instanceof stream): false;
 
   self.options.uri = assembleUrl(self, uri);
   self.options.method = 'POST';


### PR DESCRIPTION
Automatically set the binary flag when passing a stream to upload.
This should improve the UX in the library since you no longer need to pass it manually (unclear in the documentation) and stamps this library as "just works" with streams.