### PR TITLE
Fix tickets.exportSample function param

### DIFF
--- a/lib/client/tickets.js
+++ b/lib/client/tickets.js
@@ -111,7 +111,7 @@ Tickets.prototype.export = function (startTime, cb) {
 };
 
 // ====================================== Ticket Export Sample (max 50 tickets per request)
-Tickets.prototype.exportSample = function (startTime, options) {
+Tickets.prototype.exportSample = function (startTime, cb) {
   this.request('GET', ['exports', 'tickets', 'sample', {start_time: startTime}],  cb);
 };
 


### PR DESCRIPTION
Currently the `tickets.exportSample` function has an unused `options` param in the signature instead of the appropriate `cb` param, causing a null pointer on the `cb` variable. Here's the fix