### PR TITLE
Added method to replace existing tags

### DIFF
--- a/lib/client/tickets.js
+++ b/lib/client/tickets.js
@@ -148,3 +148,10 @@ Tickets.prototype.exportAudit = function (ticketID, cb) {
 Tickets.prototype.addTags = function (ticketID, tags, cb) {
   this.requestAll('PUT', ['tickets', ticketID, 'tags'], tags, cb);
 };
+
+
+
+// ====================================== Replace Tags to Ticket
+Tickets.prototype.updateTags = function (ticketID, tags, cb) {
+  this.requestAll('POST', ['tickets', ticketID, 'tags'], tags, cb);
+};


### PR DESCRIPTION
This way I can send only new tags to be available in the ticket, thus removing existing tags and add new tags becomes one function

Documentation: https://developer.zendesk.com/rest_api/docs/support/tags#set-tags