### PR TITLE
fix: ERR_STREAM_WRITE_AFTER_END

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -198,6 +198,8 @@ Client.prototype.requestUpload = function (uri, file, callback) {
 
   self.options.uri = assembleUrl(self, uri);
   self.options.method = 'POST';
+  // Fixes ERR_STREAM_WRITE_AFTER_END after new ticket creation
+  if (self.options.body) delete self.options.body
 
   self.options.headers = {'Content-Type': 'application/binary'};
 


### PR DESCRIPTION
This PR fixes `ERR_STREAM_WRITE_AFTER_END` error after creating new Zendesk ticket and then trying to upload new attachment.
