### PR TITLE
Services API Implementation (Jira Integration)

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,6 +13,7 @@
 - [Core API Methods](https://github.com/blakmatrix/node-zendesk#core-api-methods)
 - [Help Center API Methods](https://github.com/blakmatrix/node-zendesk#help-center-api-methods)
 - [Voice API Methods](https://github.com/blakmatrix/node-zendesk#voice-api-methods)
+- [Services API Methods](https://github.com/blakmatrix/node-zendesk#services-api-methods)
 - [Contributions](https://github.com/blakmatrix/node-zendesk#contributions)
 
 ## Example
@@ -65,13 +66,14 @@ var client = zendesk.createClient({
 Below is a list of options you may use when calling any scripts you may have written
 
 ```
--s  --subdomain X
--u  --username X
--p  --password X
--t  --token X
--r  --remoteUri X
--hc --helpcenter
--v  --voice
+-s    --subdomain X
+-u    --username X
+-p    --password X
+-t    --token X
+-r    --remoteUri X
+-hc   --helpcenter
+-v    --voice
+-serv --services
 --debug
 --no-cookies
 --timeout X(ms)
@@ -792,6 +794,17 @@ update(phoneID, phone_number, cb)
 delete(phoneID, cb)
 ```
 
+## Services API Methods
+(See: https://developer.zendesk.com/rest_api/docs/services/jira)
+To enable help center client, use `-serv` or `--services` parameter.
+
+### links
+
+```js
+list(cb)
+show(ticketID, cb)
+
+```
 
 ## Contributions
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,6 +21,9 @@ var parts = [
     voiceParts = [
       'PhoneNumbers', 'GreetingCategories', 'Greetings', 'CurrentQueueActivity',
       'HistoricalQueueActivity', 'AgentActivity', 'Availabilities'
+    ],
+    servicesParts = [
+      'Links' //This will be sent in undercase down to the client path
     ];
 
 exports.createClient = function (options) {
@@ -49,6 +52,9 @@ exports.createClient = function (options) {
       },
       'v': {
         alias: 'voice'
+      },
+      'serv': {
+        alias: 'services'
       }
     });
   }
@@ -61,6 +67,8 @@ exports.createClient = function (options) {
       endpoint = '.zendesk.com/api/v2/help_center';
     } else if (options.stores.defaults.store.voice){
       endpoint = '.zendesk.com/api/v2/channels/voice';
+    } else if (options.stores.defaults.store.services){
+      endpoint = '.zendesk.com/api/services/jira';
     } else {
       endpoint = '.zendesk.com/api/v2';
     }
@@ -75,6 +83,9 @@ exports.createClient = function (options) {
   } else if (options.stores.defaults.store.voice) {
     partsToAdd = voiceParts;
     clientPath = './client/voice/';
+  } else if (options.stores.defaults.store.services) {
+    partsToAdd = servicesParts;
+    clientPath = './client/services/'; //This is where parts get added to to search in the "services" folder
   } else {
     partsToAdd = parts;
     clientPath = './client/';

--- a/lib/client/services/links.js
+++ b/lib/client/services/links.js
@@ -1,0 +1,27 @@
+//Links.js: Client for the zendesk services API.
+
+var util        = require('util'),
+    Client      = require('../client').Client
+
+var Links = exports.Links = function (options) {
+  this.jsonAPINames = [ 'links' ];
+  this.sideLoadMap = [
+    { field: 'ticket_id', name: 'ticket', dataset: 'tickets' }
+  ];
+  Client.call(this, options);
+};
+
+// Inherit from Client base object
+util.inherits(Links, Client);
+
+// ######################################################## Links
+// ====================================== Listing Linnks
+Links.prototype.list = function (cb) {
+  this.requestAll('GET', ['links'], cb);//all
+};
+
+// ====================================== Viewing Links
+Links.prototype.show = function (ticket_ids, cb) {
+  this.request('GET', ['links', '?ticket_id=' + ticket_ids.toString()], cb);
+};
+


### PR DESCRIPTION
For reference of testing this, here is an example client I used basically when testing this on my own (with my own companies remote though):
```
var client = zendesk.createClient({
  username:  'username',
  token:     'oauth_token',
  remoteUri: 'https://remote.zendesk.com/api/services/jira',
  services: true
});
```

**This pull request is to add support for Services API.**

Introduction
The Services feature can be enabled by -serv or --services or {services: true} in options.
When servicesis enabled, main site api will be disabled (servicesParts instead of parts will be exported in client.js).

What has been done
- API's "Show Link" and "List Link" at https://developer.zendesk.com/rest_api/docs/services/jira are implemented, was not able to test others as I was limited to what I was supposed to implement for this at my work placement, and they had no need to create links or delete them from tickets. I saw a few people here ask about it, so here it is.
- I have tested both of these extensively and can say they work fine for me.
- ReadMe have been updated for the Service API to have documentation

Thank you~!