### PR TITLE
Allow subdomain to be set from clientCreate options #287

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -115,7 +115,15 @@ exports.createClient = function(options) {
 
   options = store.defaults(options);
 
-  if (nconf.get('subdomain')) {
+  var subdomain
+  // Allow subdomain to be supplied when global state disabled (library mode)
+  if (options.stores.defaults.store.subdomain) {
+    subdomain = options.stores.defaults.store.subdomain
+  }
+  if (!subdomain) {
+    subdomain = nconf.get('subdomain');
+  }
+  if (subdomain) {
     var endpoint;
     if (options.stores.defaults.store.helpcenter) {
       endpoint = '.zendesk.com/api/v2/help_center';
@@ -127,7 +135,7 @@ exports.createClient = function(options) {
       endpoint = '.zendesk.com/api/v2';
     }
     options.stores.defaults.store.remoteUri =
-      'https://' + nconf.get('subdomain') + endpoint;
+      'https://' + subdomain + endpoint;
   }
 
   var client = {},


### PR DESCRIPTION
Allow subdomain to be set from clientCreate options #287

Please consider this change to using subdomain when using node-zendesk as a library.  If I'm going about this all wrong, just point that out.  I'm happy to use this in the proper manner.  

Usage:
  const zenClient = zendesk.createClient({
    'username': "someone@pryon.com",
    'token': "someoneapitoken",
    'subdomain': 'pryon',
    'helpcenter': true,
    'disableGlobalState': true,
    'debug': false, // if you want to debug in library only mode, you'll have to include this
  });

  zenClient.articles.list()
      .then(function(articles) {
        stdCfg.Logr.info('Articles: ', articles);
      })
      .catch(function(error) {
        stdCfg.Logr.error('List articles error:', error);
      });