### PR TITLE
Add search capability for triggers

### DIFF
--- a/lib/client/triggers.js
+++ b/lib/client/triggers.js
@@ -13,6 +13,11 @@ var Triggers = exports.Triggers = function (options) {
 util.inherits(Triggers, Client);
 
 // ######################################################## Triggers
+// ====================================== Searching Triggers
+Triggers.prototype.search = function(searchTerm, cb) {
+    return this.request('GET', ['triggers', 'search', {query: searchTerm}], cb);
+};
+
 // ====================================== Listing Triggers
 Triggers.prototype.list = function (cb) {
   return this.requestAll('GET', ['triggers'], cb);//all


### PR DESCRIPTION
Hi @blackmatrix!  Thank you for this client.  I have a request to add the ability for the client to access the following endpoint: `/api/v2/triggers/search.json?query=<some-search-term>` which will return all triggers with a matching query `searchTerm` in the title. 