### PR TITLE
List users with filter

### DIFF
--- a/lib/client/users.js
+++ b/lib/client/users.js
@@ -26,6 +26,10 @@ Users.prototype.list = function (cb) {
   return this.requestAll('GET', ['users'], cb);
 };
 
+Users.prototype.listWithFilter = function (type, value, cb) {
+  return this.requestAll('GET', ['users', { [type]: value }], cb);
+};
+
 Users.prototype.listByGroup = function (id, cb) {
   return this.requestAll('GET', ['groups', id, 'users'], cb);
 };


### PR DESCRIPTION
I followed the pattern based on another PR for tickets: https://github.com/blakmatrix/node-zendesk/pull/116. This filter is important because my client has so many end-users, the response seems to never come back. But if I filter by agent/admin, it comes back pretty quick.