### PR TITLE
Add methods to get permission groups

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -48,7 +48,8 @@ var parts = [
     'Sessions',
     'Installations',
     'Policies',
-    'Automations'
+    'Automations',
+    'PermissionGroups'
   ],
   helpcenterParts = [
     'Articles',

--- a/lib/client/permissiongroups.js
+++ b/lib/client/permissiongroups.js
@@ -1,0 +1,44 @@
+// PermissionGroups.js: Client for the zendesk API.
+
+
+var util        = require('util'),
+  Client      = require('./client').Client;
+
+var PermissionGroups = exports.PermissionGroups = function (options) {
+  this.jsonAPINames = [ 'permission_groups' ];
+
+  Client.call(this, options);
+};
+
+// Inherit from Client base object
+util.inherits(PermissionGroups, Client);
+
+// ######################################################## Permission Groups
+
+// ====================================== Listing Permission Groups
+
+PermissionGroups.prototype.list = function (cb) {
+  console.log('list')
+  return this.requestAll('GET', ['guide', 'permission_groups'], cb);//all
+};
+
+// ====================================== Viewing Permission Groups
+
+PermissionGroups.prototype.show = function (groupID, cb) {
+  return this.request('GET', ['guide', 'permission_groups', groupID], cb);
+};
+
+// ====================================== Creating Permission Groups
+PermissionGroups.prototype.create = function (group, cb) {
+  return this.request('POST', ['guide', 'permission_groups'], group, cb);
+};
+
+// ====================================== Updating Permission Groups
+PermissionGroups.prototype.update = function (categoryID, category, cb) {
+  return this.request('PUT', ['guide', 'permission_groups', categoryID], category, cb);
+};
+
+// ====================================== Deleting Permission Groups
+PermissionGroups.prototype.delete = function (categoryID, cb) {
+  return this.request('DELETE', ['guide', 'permission_groups', categoryID],  cb);
+};

--- a/lib/client/permissiongroups.js
+++ b/lib/client/permissiongroups.js
@@ -18,7 +18,6 @@ util.inherits(PermissionGroups, Client);
 // ====================================== Listing Permission Groups
 
 PermissionGroups.prototype.list = function (cb) {
-  console.log('list')
   return this.requestAll('GET', ['guide', 'permission_groups'], cb);//all
 };
 

--- a/lib/client/permissiongroups.js
+++ b/lib/client/permissiongroups.js
@@ -34,11 +34,11 @@ PermissionGroups.prototype.create = function (group, cb) {
 };
 
 // ====================================== Updating Permission Groups
-PermissionGroups.prototype.update = function (categoryID, category, cb) {
-  return this.request('PUT', ['guide', 'permission_groups', categoryID], category, cb);
+PermissionGroups.prototype.update = function (groupID, group, cb) {
+  return this.request('PUT', ['guide', 'permission_groups', groupID], group, cb);
 };
 
 // ====================================== Deleting Permission Groups
-PermissionGroups.prototype.delete = function (categoryID, cb) {
-  return this.request('DELETE', ['guide', 'permission_groups', categoryID],  cb);
+PermissionGroups.prototype.delete = function (groupID, cb) {
+  return this.request('DELETE', ['guide', 'permission_groups', groupID],  cb);
 };


### PR DESCRIPTION
I needed to access the permission groups, because a group_permission_id is required to create an article in the help center. Here's documentation: https://developer.zendesk.com/rest_api/docs/help_center/permission_groups. I didn't add it to the 'helpcenter' methods because the client path starts with /guide instead of /help_center.