### PR TITLE
Add trigger definitions endpoint to the client

### DIFF
--- a/lib/client/triggers.js
+++ b/lib/client/triggers.js
@@ -18,6 +18,11 @@ Triggers.prototype.search = function(searchTerm, cb) {
     return this.request('GET', ['triggers', 'search', {query: searchTerm}], cb);
 };
 
+// ====================================== Trigger Definitions
+Triggers.prototype.definitions = function (cb) {
+  return this.requestAll('GET', ['triggers', 'definitions'], cb);
+};
+
 // ====================================== Listing Triggers
 Triggers.prototype.list = function (cb) {
   return this.requestAll('GET', ['triggers'], cb);//all


### PR DESCRIPTION
Hello again, @blakmatrix! 

This PR adds an additional endpoint for the client to access the following endpoint:  `/api/v2/triggers/definitions` which will return trigger action and condition definitions.

The Zendesk API is linked below.

https://developer.zendesk.com/rest_api/docs/support/triggers#list-trigger-action-and-condition-definitions