### PR TITLE
Added webhooks support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -49,7 +49,8 @@ var parts = [
     'Installations',
     'Policies',
     'Automations',
-    'PermissionGroups'
+    'PermissionGroups',
+    'Webhooks'
   ],
   helpcenterParts = [
     'Articles',

--- a/lib/client/webhooks.js
+++ b/lib/client/webhooks.js
@@ -1,8 +1,7 @@
 //webhooks.js: Client for the zendesk API.
 
-var util        = require('util'),
-  Client      = require('./client').Client;
-
+var util = require('util');
+var Client = require('./client').Client;
 
 var Webhooks = exports.Webhooks = function (options) {
   this.jsonAPINames = [ 'webhooks', 'webhook' ];

--- a/lib/client/webhooks.js
+++ b/lib/client/webhooks.js
@@ -1,0 +1,39 @@
+//webhooks.js: Client for the zendesk API.
+
+var util        = require('util'),
+  Client      = require('./client').Client;
+
+
+var Webhooks = exports.Webhooks = function (options) {
+  this.jsonAPINames = [ 'webhooks', 'webhook' ];
+  Client.call(this, options);
+};
+
+// Inherit from Client base object
+util.inherits(Webhooks, Client);
+
+// ######################################################## Webhooks
+// ====================================== Listing Webhooks
+Webhooks.prototype.list = function (cb) {
+  return this.requestAll('GET', '/webhooks', cb);//all
+};
+
+// ====================================== Viewing Webhooks
+Webhooks.prototype.show = function (webhookID, cb) {
+  return this.request('GET', `/webhooks/${webhookID}`, cb);
+};
+
+// ====================================== Creating Webhooks
+Webhooks.prototype.create = function (webhook, cb) {
+  return this.request('POST', '/webhooks', webhook,  cb);
+};
+
+// ====================================== Updating Webhooks
+Webhooks.prototype.update = function (webhookID, webhook, cb) {
+  return this.request('PUT', `/webhooks/${webhookID}`, webhook,  cb);
+};
+
+// ====================================== Deleting Webhooks
+Webhooks.prototype.delete = function (webhookID, cb) {
+  return this.request('DELETE', `/webhooks/${webhookID}`,  cb);
+};


### PR DESCRIPTION
According to this [article](https://support.zendesk.com/hc/en-us/articles/4408826284698-Announcing-the-deprecation-of-HTTP-targets-and-conversion-to-webhooks#:~:text=Beginning%20on%20February%2022%2C%202022,deprecated%20and%20no%20longer%20accessible.), `HTTP targets` will be deprecated on `Feb 22, 2022`. It's suggested to move to webhooks. We have some integration that creates `HTTP targets` automatically and seems like we would need to do the same with webhook. Just added basic support for webhooks.