### PR TITLE
Update nconf library due to Prototype Pollution in async vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "node-zendesk",
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.x",
-        "nconf": "0.11.3",
+        "nconf": "0.12.0",
         "querystring": "0.2.x",
         "request": "2.88.2"
       }
@@ -362,11 +361,11 @@
       }
     },
     "node_modules/nconf": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.3.tgz",
-      "integrity": "sha512-iYsAuDS9pzjVMGIzJrGE0Vk3Eh8r/suJanRAnWGBd29rVS2XtSgzcAo5l6asV3e4hH2idVONHirg1efoBOslBg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+      "integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
       "dependencies": {
-        "async": "^1.4.0",
+        "async": "^3.0.0",
         "ini": "^2.0.0",
         "secure-keys": "^1.0.0",
         "yargs": "^16.1.1"
@@ -374,11 +373,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/nconf/node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -923,21 +917,14 @@
       }
     },
     "nconf": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.3.tgz",
-      "integrity": "sha512-iYsAuDS9pzjVMGIzJrGE0Vk3Eh8r/suJanRAnWGBd29rVS2XtSgzcAo5l6asV3e4hH2idVONHirg1efoBOslBg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.12.0.tgz",
+      "integrity": "sha512-T3fZPw3c7Dfrz8JBQEbEcZJ2s8f7cUMpKuyBtsGQe0b71pcXx6gNh4oti2xh5dxB+gO9ufNfISBlGvvWtfyMcA==",
       "requires": {
-        "async": "^1.4.0",
+        "async": "^3.0.0",
         "ini": "^2.0.0",
         "secure-keys": "^1.0.0",
         "yargs": "^16.1.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
       }
     },
     "oauth-sign": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "async": "3.2.x",
-    "nconf": "0.11.3",
+    "nconf": "0.12.0",
     "querystring": "0.2.x",
     "request": "2.88.2"
   },


### PR DESCRIPTION
Fixes vulnerability https://nvd.nist.gov/vuln/detail/CVE-2021-43138 

nconf recently released 0.12.0 which fixes the above vulnerability. 

closes #341 