### PR TITLE
Use POST insteead of PUT for Organization Memberships `createMany`.

### DIFF
--- a/src/client/core/organizationmemberships.js
+++ b/src/client/core/organizationmemberships.js
@@ -116,16 +116,24 @@ class OrganizationMemberships extends Client {
   }
 
   /**
+   * An object that relates a Zendesk user to a Zendesk organization.
+   * @typedef {object} OrganizationMembership
+   * @property {number} user_id The Zendesk identifier of the user.
+   * @property {number} organization_id The Zendesk identifier of the
+   *   organization.
+   */
+
+  /**
    * Create multiple organization memberships at once.
    * @async
-   * @param {Object[]} organizationMemberships - An array of organization membership data.
+   * @param {OrganizationMembership[]} organizationMemberships - An array of organization membership data.
    * @returns {Promise<Object>} A promise resolving to a job status.
    * @see {@link https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#create-many-memberships}
    * @example
    * const jobStatus = await client.organizationmemberships.createMany([{ user_id: 123, organization_id: 456 }, ...]);
    */
   async createMany(organizationMemberships) {
-    return this.put(
+    return this.post(
       ['organization_memberships', 'create_many'],
       organizationMemberships,
     );


### PR DESCRIPTION
## Pull Request Description

Send a POST request instead of a PUT request to `organization_memberships/create_many`.

---

## Related Issue(s)

- [x] This PR fixes/closes issue #377 

---

## Additional Information

- [x] This change is a breaking change (may require a major version update)
  - I'm not sure if the PUT was an accident or intentional, but I couldn't get it working as a PUT request and required a POST so I assume that it's _not_ breaking, the existing implementation is broken but I could be wrong.
- [ ] This change is a new feature (non-breaking change which adds functionality)
- [x] This change improves the code (e.g., refactoring, etc.)
- [ ] This change includes dependency updates

---

## Test Cases

I don't really have a personal account I can run tests against, but I did verify in my company project that a POST request succeeds where a PUT fails. I did this by manually calling `Client#post` from `ZendeskClient#organizationmemberships`.

---

## Documentation

- [x] I have updated the documentation accordingly.
  - Added clarifying documentation with an additional JSDoc.
- [ ] No updates are required.

---

## Checklist

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) documentation.
- [x] My code follows the coding standards of this project.
  - There exist lint failures outside the changed files though.
- [ ] All new and existing tests passed.
  - I'm unable to run the test suite as I don't have a personal Zendesk account to run against.

