### PR TITLE
Add organizationMembershipIDs as a query parameter to the destroy_many endpoint.

### DIFF
--- a/src/client/core/organizationmemberships.js
+++ b/src/client/core/organizationmemberships.js
@@ -174,8 +174,7 @@ class OrganizationMemberships extends Client {
    */
   async deleteMany(organizationMembershipIDs) {
     return super.delete(
-      ['organization_memberships', 'destroy_many'],
-      organizationMembershipIDs,
+      ['organization_memberships', 'destroy_many', { ids: organizationMembershipIDs.join(',') }],
     );
   }
 


### PR DESCRIPTION
## Pull Request Description

The `Client#delete` method ignores a body and examples in the Zendesk documentation for bulk deleting organization memberships (https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#bulk-delete-memberships) show the data being passed a query parameter. Query parameters also seemed to be the least intrusive change available as the transporter already identifies a trailing object and creates a query parameter from it.

---

## Related Issue(s)

- [x] This PR fixes/closes issue #378 
- [ ] This is a new feature and does not have an associated issue.

---

## Additional Information

- [ ] This change is a breaking change (may require a major version update)
- [ ] This change is a new feature (non-breaking change which adds functionality)
- [x] This change improves the code (e.g., refactoring, etc.)
- [ ] This change includes dependency updates

---

## Test Cases

There did not appear to be any test cases for organization memberships, and I do not have a Zendesk account I can test against.

---

## Documentation

- [ ] I have updated the documentation accordingly.
- [x] No updates are required.

---

## Checklist

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) documentation.
- [x] My code follows the coding standards of this project.
- [ ] All new and existing tests passed.

