### PR TITLE
fix: webhooks do not use .json

### DIFF
--- a/src/clients/client.js
+++ b/src/clients/client.js
@@ -35,6 +35,7 @@ const {
  * @property {Array} sideLoad - Array to handle side-loaded resources.
  * @property {string} userAgent - User agent for the client.
  * @property {Array} jsonAPINames - Array to hold names used in the JSON API.
+ * @property {boolean} useDotJson - Flag to indicate if the API endpoint should use '.json' ending.
  * @property {ApiTypes} apiType - Type of Zendesk API to initialize (e.g., 'core', 'helpcenter').
  * @property {CustomEventTarget} eventTarget - Event target to handle custom events.
  * @property {Transporter} transporter - Transporter for making requests.
@@ -49,6 +50,7 @@ class Client {
     this.options = this._buildOptions(options, apiType);
     this.sideLoad = [];
     this.jsonAPINames = [];
+    this.useDotJson = true;
     this.userAgent = generateUserAgent();
     this.eventTarget = new CustomEventTarget();
   }

--- a/src/clients/client.js
+++ b/src/clients/client.js
@@ -59,7 +59,11 @@ class Client {
   get transporter() {
     if (this._transporter) return this._transporter;
 
-    this._transporter = new Transporter(this.options, this.sideLoad);
+    this._transporter = new Transporter(
+      this.options,
+      this.sideLoad,
+      this.useDotJson,
+    );
     // Listen to transporter's debug events and re-emit them on the Client
     this._transporter.on('debug::request', (eventData) => {
       this.emit('debug::request', eventData.detail);

--- a/src/clients/core/webhooks.js
+++ b/src/clients/core/webhooks.js
@@ -9,6 +9,7 @@ class Webhooks extends Client {
   constructor(options) {
     super(options);
     this.jsonAPINames = ['webhooks', 'webhook'];
+    this.useDotJson = false;
   }
 
   /**

--- a/src/clients/helpers.js
+++ b/src/clients/helpers.js
@@ -158,9 +158,9 @@ function assembleUrl(self, method, uri) {
   );
 
   // Construct the URL
-  const basePath = `${endpointUri}/${segments
-    .filter((segment) => segment !== undefined && segment !== '')
-    .join('/')}.json`;
+  const path = segments.filter(Boolean).join('/');
+  const extension = this.useDotJson ? '.json' : '';
+  const basePath = `${endpointUri}/${path}${extension}`;
   return queryString ? `${basePath}?${queryString}` : basePath;
 }
 

--- a/src/clients/helpers.js
+++ b/src/clients/helpers.js
@@ -159,7 +159,7 @@ function assembleUrl(self, method, uri) {
 
   // Construct the URL
   const path = segments.filter(Boolean).join('/');
-  const extension = this.useDotJson ? '.json' : '';
+  const extension = self.useDotJson === false ? '' : '.json'; // Undefined is true (default)
   const basePath = `${endpointUri}/${path}${extension}`;
   return queryString ? `${basePath}?${queryString}` : basePath;
 }

--- a/src/clients/transporter.js
+++ b/src/clients/transporter.js
@@ -24,9 +24,10 @@ const defaultTransportConfig = {
   },
 };
 class Transporter {
-  constructor(options, sideLoad = []) {
+  constructor(options, sideLoad = [], useDotJson = true) {
     this.options = options;
     this.sideLoad = sideLoad;
+    this.useDotJson = useDotJson;
     this.authHandler = new AuthorizationHandler(this.options);
     this.eventTarget = new CustomEventTarget();
     this.endpointChecker = new EndpointChecker();

--- a/test/fixtures/webhooks_endpoint.json
+++ b/test/fixtures/webhooks_endpoint.json
@@ -1,0 +1,12 @@
+[
+  {
+    "scope": "https://nodejsapi.zendesk.com:443",
+    "method": "POST",
+    "path": "/api/v2/webhooks",
+    "status": 201,
+    "response": {
+      "id": 19442893058196
+    },
+    "responseIsBinary": false
+  }
+]

--- a/test/webhooks.test.js
+++ b/test/webhooks.test.js
@@ -1,0 +1,33 @@
+import dotenv from 'dotenv';
+import { back as nockBack } from 'nock';
+import path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { setupClient } from './setup.js';
+
+dotenv.config();
+
+describe('Zendesk Client Webhooks', () => {
+  const client = setupClient();
+
+  beforeAll(async () => {
+    nockBack.setMode('record');
+    nockBack.fixtures = path.join(__dirname, '/fixtures');
+  });
+
+  it('should call endpoint without .json', async () => {
+    const { nockDone } = await nockBack('webhooks_endpoint.json');
+    const { result } = await client.webhooks.create({
+      webhook: {
+        name: `Web Hulk`,
+        endpoint: 'noop://noop',
+        http_method: 'POST',
+        request_format: 'json',
+        status: 'active',
+        subscriptions: ['conditional_ticket_events']
+      }
+    });
+    nockDone();
+
+    expect(result.id).toBeDefined();
+  });
+});

--- a/test/webhooks.test.js
+++ b/test/webhooks.test.js
@@ -1,8 +1,8 @@
-import dotenv from 'dotenv';
-import { back as nockBack } from 'nock';
 import path from 'node:path';
-import { beforeAll, describe, expect, it } from 'vitest';
-import { setupClient } from './setup.js';
+import dotenv from 'dotenv';
+import {back as nockBack} from 'nock';
+import {beforeAll, describe, expect, it} from 'vitest';
+import {setupClient} from './setup.js';
 
 dotenv.config();
 
@@ -15,16 +15,16 @@ describe('Zendesk Client Webhooks', () => {
   });
 
   it('should call endpoint without .json', async () => {
-    const { nockDone } = await nockBack('webhooks_endpoint.json');
-    const { result } = await client.webhooks.create({
+    const {nockDone} = await nockBack('webhooks_endpoint.json');
+    const {result} = await client.webhooks.create({
       webhook: {
         name: `Web Hulk`,
         endpoint: 'noop://noop',
         http_method: 'POST',
         request_format: 'json',
         status: 'active',
-        subscriptions: ['conditional_ticket_events']
-      }
+        subscriptions: ['conditional_ticket_events'],
+      },
     });
     nockDone();
 


### PR DESCRIPTION
Webhooks API do not accept `.json` ending

https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/#create-or-clone-webhook


