### PR TITLE
Update exports definition in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,14 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
Change-type: patch

---

This updates the `exports` definition in `package.json` to resolve this error found when attempting to import and use the module: `There are types at 'node_modules/node-zendesk/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'node-zendesk' library may need to update its package.json or typings.`