### PR TITLE
fix: update request method and body of createOrUpdateOption

### DIFF
--- a/src/clients/core/ticketfields.js
+++ b/src/clients/core/ticketfields.js
@@ -147,12 +147,14 @@ class TicketFields extends Client {
    * @example
    * const client = createClient({...});
    * const newOption = await client.ticketfields.createOrUpdateOption(12345, {
-   *   name: 'Option Name',
-   *   value: 'Option Value'
+   *   custom_field_option: {
+   *     name: 'Option Name',
+   *     value: 'Option Value'
+   *   }
    * });
    */
   async createOrUpdateOption(ticketFieldId, option) {
-    return this.put(['ticket_fields', ticketFieldId, 'options'], option);
+    return this.post(['ticket_fields', ticketFieldId, 'options'], option);
   }
 
   /**


### PR DESCRIPTION
## Pull Request Description

Follow the official api reference 
https://developer.zendesk.com/api-reference/ticketing/tickets/ticket_fields/#create-or-update-ticket-field-option 

The http request method was change from `PUT` to `POST`, and the option object change with a parent key `custom_field_option`

---

## Related Issue(s)

- [ ] This PR fixes/closes issue #...
- [x] This is a new feature and does not have an associated issue.

---

## Additional Information

- [ ] This change is a breaking change (may require a major version update)
- [ ] This change is a new feature (non-breaking change which adds functionality)
- [x] This change improves the code (e.g., refactoring, etc.)
- [ ] This change includes dependency updates

---

## Test Cases

Include any test cases or steps you took to test your changes. If you have added new functionality, please include relevant unit tests.

---

## Documentation

- [ ] I have updated the documentation accordingly.
- [x] No updates are required.

---

## Checklist

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) documentation.
- [x] My code follows the coding standards of this project.
- [x] All new and existing tests passed.

