### PR TITLE
feat: tickets & users types + adjustments on types exports + option to throwOriginalException

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,36 @@
         "types": "./dist/types/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./clients/*": {
+      "import": {
+        "types": "./dist/types/clients/*.d.ts",
+        "default": "./dist/clients/*.js"
+      },
+      "require": {
+        "types": "./dist/types/clients/*.d.ts",
+        "default": "./dist/clients/*.js"
+      }
+    },
+    "./clients/*/*": {
+      "import": {
+        "types": "./dist/types/clients/*/*.d.ts",
+        "default": "./dist/clients/*/*.js"
+      },
+      "require": {
+        "types": "./dist/types/clients/*/*.d.ts",
+        "default": "./dist/clients/*/*.js"
+      }
+    },
+    "./clients/*/*/*": {
+      "import": {
+        "types": "./dist/types/clients/*/*/*.d.ts",
+        "default": "./dist/clients/*/*/*.js"
+      },
+      "require": {
+        "types": "./dist/types/clients/*/*/*.d.ts",
+        "default": "./dist/clients/*/*/*.js"
+      }
     }
   },
   "files": [

--- a/src/clients/client.js
+++ b/src/clients/client.js
@@ -167,7 +167,7 @@ class Client {
       !Array.isArray(args.at(-1)) &&
       args.pop();
 
-    return await this.transporter.request(method, uri, body);
+    return this.transporter.request(method, uri, body);
   }
 
   /**
@@ -234,8 +234,8 @@ class Client {
         hasCursorPagination(page)
           ? page.links.next
           : hasOffsetPagination(page)
-            ? page.next_page
-            : null;
+          ? page.next_page
+          : null;
       const item = processResponseBody(currentPage, this);
 
       bodyList.push(item);
@@ -245,12 +245,7 @@ class Client {
 
     const fetchPagesRecursively = async (pageUri) => {
       const isIncremental = pageUri.includes('incremental');
-      const responseData = await __request.call(
-        this,
-        method,
-        pageUri,
-        ...args,
-      );
+      const responseData = await __request.call(this, method, pageUri, ...args);
       const nextPage = processPage(responseData);
       if (
         nextPage &&

--- a/src/clients/client.js
+++ b/src/clients/client.js
@@ -234,8 +234,8 @@ class Client {
         hasCursorPagination(page)
           ? page.links.next
           : hasOffsetPagination(page)
-          ? page.next_page
-          : null;
+            ? page.next_page
+            : null;
       const item = processResponseBody(currentPage, this);
 
       bodyList.push(item);

--- a/src/clients/client.js
+++ b/src/clients/client.js
@@ -21,6 +21,7 @@ const {
  * @property {string} [asUser] - Optional header for making requests on behalf of a user.
  * @property {object} [customHeaders] - Any additional custom headers for the request.
  * @property {boolean} [throttle] - Flag to enable throttling of requests.
+ * @property {boolean} [throwOriginalException] - Throw the original exception when API requests fail.
  * @property {CustomEventTarget} eventTarget - Event target to handle custom events.
  * @property {Array} sideLoad - Array to handle side-loaded resources.
  * @property {Array} jsonAPINames - Array to hold names used in the JSON API.
@@ -166,11 +167,7 @@ class Client {
       !Array.isArray(args.at(-1)) &&
       args.pop();
 
-    try {
-      return await this.transporter.request(method, uri, body);
-    } catch (error) {
-      throw new Error(`Raw request failed: ${error.message}`);
-    }
+    return await this.transporter.request(method, uri, body);
   }
 
   /**
@@ -197,6 +194,10 @@ class Client {
       );
       return {response, result: responseBody};
     } catch (error) {
+      if (this.options.throwOriginalException) {
+        throw error;
+      }
+
       const {
         message,
         result: {error: {title = '', message: errorMessage = ''} = {}} = {},
@@ -244,43 +245,30 @@ class Client {
 
     const fetchPagesRecursively = async (pageUri) => {
       const isIncremental = pageUri.includes('incremental');
-
-      try {
-        const responseData = await __request.call(
-          this,
-          method,
-          pageUri,
-          ...args,
-        );
-        const nextPage = processPage(responseData);
-        if (
-          nextPage &&
-          (!isIncremental ||
-            (responseData.response && responseData.response.count >= 1000))
-        ) {
-          return fetchPagesRecursively(nextPage);
-        }
-      } catch (error) {
-        throw new Error(`Request all failed during fetching: ${error.message}`);
+      const responseData = await __request.call(
+        this,
+        method,
+        pageUri,
+        ...args,
+      );
+      const nextPage = processPage(responseData);
+      if (
+        nextPage &&
+        (!isIncremental ||
+          (responseData.response && responseData.response.count >= 1000))
+      ) {
+        return fetchPagesRecursively(nextPage);
       }
     };
 
-    try {
-      await fetchPagesRecursively(uri);
-      return flatten(bodyList);
-    } catch (error) {
-      throw new Error(`RequestAll processing failed: ${error.message}`);
-    }
+    await fetchPagesRecursively(uri);
+    return flatten(bodyList);
   }
 
   // Request method for uploading files
   async requestUpload(uri, file) {
-    try {
-      const {response, result} = await this.transporter.upload(uri, file);
-      return checkRequestResponse(response, result);
-    } catch (error) {
-      throw new Error(`Upload failed: ${error.message}`);
-    }
+    const {response, result} = await this.transporter.upload(uri, file);
+    return checkRequestResponse(response, result);
   }
 }
 

--- a/src/clients/core/tickets.js
+++ b/src/clients/core/tickets.js
@@ -348,7 +348,7 @@ class Tickets extends Client {
    * Update an existing ticket by its ID.
    * @param {number} ticketId - The ID of the ticket to update.
    * @param {CreateOrUpdateTicket} ticket - The updated ticket data as an object.
-   * @returns {Promise<{result: Ticket}>} A promise that resolves to the updated ticket object.
+   * @returns {Promise<{result: Ticket, response: {ticket:Ticket, audit:any[]}}>} A promise that resolves to the updated ticket object.
    * @async
    * @throws {Error} If `ticketId` is not a number or if `ticket` is not an object.
    * @see {@link https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#update-ticket}

--- a/src/clients/core/users.js
+++ b/src/clients/core/users.js
@@ -138,7 +138,7 @@ class Users extends Client {
   /**
    * Shows details of a user by ID.
    * @param {number} id - The ID of the user.
-   * @returns {Promise<User>} The user's details.
+   * @returns {Promise<{result: User}>} The user's details.
    * @async
    * @see {@link https://developer.zendesk.com/api-reference/ticketing/users/users/#show-user}
    * @example

--- a/src/clients/helpers.js
+++ b/src/clients/helpers.js
@@ -54,8 +54,8 @@ function populateFields(data, response, map) {
           record[name] = all
             ? responseDataset
             : array
-              ? findAllRecordsById(responseDataset, key, record[field])
-              : findOneRecordById(responseDataset, key, record[field]);
+            ? findAllRecordsById(responseDataset, key, record[field])
+            : findOneRecordById(responseDataset, key, record[field]);
         }
       }
     }

--- a/src/clients/helpers.js
+++ b/src/clients/helpers.js
@@ -54,8 +54,8 @@ function populateFields(data, response, map) {
           record[name] = all
             ? responseDataset
             : array
-            ? findAllRecordsById(responseDataset, key, record[field])
-            : findOneRecordById(responseDataset, key, record[field]);
+              ? findAllRecordsById(responseDataset, key, record[field])
+              : findOneRecordById(responseDataset, key, record[field]);
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const {ZendeskClientVoice} = require('./clients/voice');
 /**
  * @typedef {object} ZendeskClientOptions
  * @property {string} [token] - Authentication token.
+ * @property {string} [password] - Authentication password.
  * @property {string} [username] - Username for authentication.
  * @property {string} [subdomain] - Subdomain for the Zendesk account (e.g., 'mycompany' for 'mycompany.zendesk.com'). If `endpointUri` is provided, this is ignored.
  * @property {string[]} [apiType=['core']] - Type of Zendesk API (e.g., 'core', 'helpcenter'). Determines the sub-client to use.

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const {ZendeskClientVoice} = require('./clients/voice');
  * @property {string} [asUser] - Optional header for requests on behalf of a user.
  * @property {object} [customHeaders] - Additional custom headers for the request.
  * @property {boolean} [throttle] - Enables request throttling.
+ * @property {boolean} [throwOriginalException] - Throw the original exception when API requests fail.
  * @property {boolean} [debug=false] - Enables or disables debug logging.
  * @property {object} [logger=ConsoleLogger] - Logger for logging. Defaults to a basic console logger.
  * @property {object} [transportConfig] - Configuration for custom transport.

--- a/test/exceptionshandling.test.js
+++ b/test/exceptionshandling.test.js
@@ -1,0 +1,30 @@
+import process from 'node:process';
+import dotenv from 'dotenv';
+import {describe, expect, it} from 'vitest';
+import {initializeClient} from './setup.js';
+
+dotenv.config();
+
+const username = process.env.ZENDESK_USERNAME;
+const token = process.env.ZENDESK_TOKEN;
+
+describe('Zendesk Exceptions Handling', () => {
+  it('should throw an error for an invalid subdomain', async () => {
+    const error = new Error('My Custom Error');
+    error.details = 'Custom Details';
+
+    const client = initializeClient({
+      username,
+      token,
+      subdomain: 'any',
+      throwOriginalException: true,
+      transportConfig: {
+        transportFn() {
+          throw error;
+        },
+      },
+    });
+
+    await expect(() => client.users.me()).rejects.toThrowError(error);
+  });
+});


### PR DESCRIPTION
## Pull Request Description

### Updated some types on tickets and users clients;

### Updated exports config on package.json so we can import types directly from the client;

before the update
```ts
import { ZendeskClient } from 'node-zendesk';

export type ZendeskInstanceType = InstanceType<typeof ZendeskClient>;
export type CreateOrUpdateTicket = Parameters<ZendeskInstanceType['tickets']['create']>[0]['ticket']['comment'];
```

after the update

```ts
import { CreateOrUpdateTicket } from 'node-zendesk/clients/core/tickets';
```

### Added option on createClient to allow rethrow the original exception;

In many scenarios the lib is just swallowing the original exception by creating a new exception with just a new message prefix, this is bad because you loose all the original fields of the exception thrown by the transporter request.

This option allows the lib to throw the original exception as is and let the user decide what to do with it.

```ts
createClient({
    throwOriginalException: true
});
```

---

## Additional Information

- [ ] This change is a breaking change (may require a major version update)
- [x] This change is a new feature (non-breaking change which adds functionality)
- [x] This change improves the code (e.g., refactoring, etc.)
- [ ] This change includes dependency updates


## Documentation

- [ ] I have updated the documentation accordingly.
- [x] No updates are required.

---

## Checklist

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) documentation.
- [x] My code follows the coding standards of this project.
- [x] All new and existing tests passed.

