### PR TITLE
feat(client): obfuscate token while logging in debug mode

### DIFF
--- a/src/clients/transporter.js
+++ b/src/clients/transporter.js
@@ -23,9 +23,19 @@ const defaultTransportConfig = {
     };
   },
 };
+
+const obfuscateToken = (options) => {
+  if (!options.token) return options;
+
+  return {
+    ...options,
+    token: options.token.slice(0, 5) + '**********',
+  };
+};
+
 class Transporter {
   constructor(options, sideLoad = [], useDotJson = true) {
-    this.options = options;
+    this.options = obfuscateToken(options);
     this.sideLoad = sideLoad;
     this.useDotJson = useDotJson;
     this.authHandler = new AuthorizationHandler(this.options);


### PR DESCRIPTION
## Pull Request Description

Obfuscate the token in the transporter class used to log things in debug mode
---

## Related Issue(s)

- [x] This is a new feature and does not have an associated issue.

---

## Additional Information

- [x] This change is a breaking change if you are expecting to see plain tokens in logs

---

## Test Cases

No test included. Build and use it in my code, this is my result:

![image](https://github.com/user-attachments/assets/86f48d2f-ba10-41a1-a94c-4217e2d35deb)

---

## Documentation


- [x] No updates are required.

---

## Checklist

- [x] I have read the [CONTRIBUTING](./CONTRIBUTING.md) documentation.
- [x] My code follows the coding standards of this project.
- [x] All new and existing tests passed.

